### PR TITLE
Add LCR mode to chemical plant + fixes (processing plant + transcendental space time casing)

### DIFF
--- a/.minecraft/kubejs/server_scripts/mainlines/gregification.js
+++ b/.minecraft/kubejs/server_scripts/mainlines/gregification.js
@@ -241,7 +241,7 @@ ServerEvents.recipes(sog => {
         .itemInputs('16x kubejs:space_time_heavy_plating')
         .itemOutputs('kubejs:trascendental_space_time_casing')
         .EUt(32)
-        .circuit(8)
+        .circuit(6)
         sog.recipes.gtceu.assembler('high_power_casing_plant')
         .itemInputs('8x gtceu:osmiridium_plate', 'gtceu:secure_maceration_casing')
         .itemOutputs('kubejs:high_power_casing')

--- a/.minecraft/kubejs/startup_scripts/multiblocks/bacterial/chemical_plant.js
+++ b/.minecraft/kubejs/startup_scripts/multiblocks/bacterial/chemical_plant.js
@@ -15,7 +15,7 @@ GTCEuStartupEvents.registry('gtceu:recipe_type', event => {
 GTCEuStartupEvents.registry('gtceu:machine', event => {
     event.create('chemical_plant', 'multiblock')
         .rotationState(RotationState.NON_Y_AXIS)
-        .recipeType('chemical_plant')
+        .recipeTypes(['chemical_plant', 'large_chemical_reactor'])
         .recipeModifiers([GTRecipeModifiers.PARALLEL_HATCH, GTRecipeModifiers.OC_PERFECT_SUBTICK])
         .appearanceBlock(() => Block.getBlock('gtceu:inert_machine_casing'))
         .pattern(definition => FactoryBlockPattern.start()

--- a/.minecraft/kubejs/startup_scripts/multiblocks/processing_plant.js
+++ b/.minecraft/kubejs/startup_scripts/multiblocks/processing_plant.js
@@ -15,7 +15,7 @@ GTCEuStartupEvents.registry('gtceu:machine', event => {
     event.create('processing_plant', 'multiblock')
         .rotationState(RotationState.ALL)
         .recipeType('processing_plant')
-        .recipeModifiers([GTRecipeModifiers.OC_PERFECT, GTRecipeModifiers.PARALLEL_HATCH])
+        .recipeModifiers([GTRecipeModifiers.PARALLEL_HATCH, GTRecipeModifiers.OC_PERFECT])
         .appearanceBlock(() => Block.getBlock('kubejs:high_power_casing'))
         .pattern(definition => FactoryBlockPattern.start()      
         .aisle('#C#C#', '#C#C#', '#CCC#', 'CCCCC', '#CCC#')


### PR DESCRIPTION
Fixing PCH on processing plant, order always should have PCH first or it won't work as intended
Probably not fixable without reordering - GTM would need to fix prefereing PCH tags always