### PR TITLE
fix fluid filter recipes

### DIFF
--- a/.minecraft/kubejs/server_scripts/hideremove.js
+++ b/.minecraft/kubejs/server_scripts/hideremove.js
@@ -133,7 +133,6 @@ ServerEvents.recipes(event => {
     event.remove({ output: 'ae2:molecular_assembler'})
     event.remove({ id: 'solarflux:photovoltaic_cell_1' })
     event.remove({ output: 'solarflux:mirror'})
-    event.remove({ output: 'gtceu:fluid_filter'})
     event.remove({ output: 'fluxnetworks:flux_dust'})
     event.remove({ output: 'bloodmagic:blankrune'})
     event.remove({ output: 'bloodmagic:altar'})

--- a/.minecraft/kubejs/server_scripts/mainlines/gregification.js
+++ b/.minecraft/kubejs/server_scripts/mainlines/gregification.js
@@ -669,14 +669,15 @@ ServerEvents.recipes(sog => {
           .itemOutputs("gtceu:ruthenium_dust")
           .duration(400)
           .EUt(32)
-      sog.shaped(
-            'gtceu:fluid_filter',
-            ['AAA', 'AWA', 'AAA'],
-            {
-                A: 'gtceu:steel_foil',
-                W: 'minecraft:water_bucket'
-            }
-          ).id('gtceu:filterfluid')
+      const gems = ["lapis", "sodalite", "lazurite"]
+      gems.forEach(gem => {
+        sog.recipes.gtceu.compressor(`${gem}_plate`)
+          .itemInputs(`gtceu:${gem}_dust`)
+          .itemOutputs(`gtceu:${gem}_plate`)
+          .duration(20 * 15)
+          .EUt(2)
+      })
+      sog.recipes.gtceu.compressor("compress_plate_")
       sog.recipes.gtceu.arc_furnace('platinumsludge')
           .itemInputs('gtceu:platinum_dust')
           .inputFluids('gtceu:nitric_acid 1000')

--- a/.minecraft/kubejs/server_scripts/mainlines/gregification.js
+++ b/.minecraft/kubejs/server_scripts/mainlines/gregification.js
@@ -677,7 +677,6 @@ ServerEvents.recipes(sog => {
           .duration(20 * 15)
           .EUt(2)
       })
-      sog.recipes.gtceu.compressor("compress_plate_")
       sog.recipes.gtceu.arc_furnace('platinumsludge')
           .itemInputs('gtceu:platinum_dust')
           .inputFluids('gtceu:nitric_acid 1000')


### PR DESCRIPTION
- add the default fluid filter recipes back, which are automatable and include the nbt reset recipe
- remove the custom fluid filter recipe
- add compressor recipes to gem plates that are used in fluid filter recipes (lapis, lazurite, sodalite), so that you can make them without needing a cutter