### PR TITLE
resolve endgame recipe conflicts

### DIFF
--- a/.minecraft/kubejs/server_scripts/fusion.js/plasma_nexus.js
+++ b/.minecraft/kubejs/server_scripts/fusion.js/plasma_nexus.js
@@ -1,20 +1,20 @@
-ServerEvents.recipes(sog => {
+ServerEvents.recipes(event => {
+  event.recipes.gtceu.plasma_nexus("energized_anomaly")
+    .itemInputs(Item.of("kubejs:quantum_anomaly", 2))
+    .inputFluids(
+      Fluid.of("gtceu:eternity", 20),
+      Fluid.of("gtceu:hypercharged_nihonium_plasma", 256000)
+    )
+    .itemOutputs("1x kubejs:energized_quantum_anomaly")
+    .circuit(2)
+    .duration(20 * 323)
+    .EUt(GTValues.VA[GTValues.UXV])
 
-
-
-sog.recipes.gtceu.plasma_nexus('energized_anomaly')
-.circuit(1)
-.inputFluids('gtceu:eternity 20', 'gtceu:hypercharged_nihonium_plasma 256000')
-.itemInputs('2x kubejs:quantum_anomaly')
-.itemOutputs('1x kubejs:energized_quantum_anomaly')
-.duration(64*60)
-.EUt(GTValues.VA[GTValues.UXV]);
-sog.recipes.gtceu.plasma_nexus('quantum_anomaly')
-.inputFluids('gtceu:eternity 20')
-.itemInputs('1x kubejs:quantum_anomaly')
-.itemOutputs('2x kubejs:quantum_anomaly')
-.duration(64*60)
-.EUt(GTValues.VA[GTValues.UXV]);
-
-
+  event.recipes.gtceu.plasma_nexus("quantum_anomaly")
+    .itemInputs(Item.of("kubejs:quantum_anomaly"))
+    .inputFluids(Fluid.of("gtceu:eternity", 20))
+    .itemOutputs(Item.of("kubejs:quantum_anomaly", 2))
+    .circuit(1)
+    .duration(20 * 323)
+    .EUt(GTValues.VA[GTValues.UXV])
 })

--- a/.minecraft/kubejs/server_scripts/fusion.js/plasma_nexus.js
+++ b/.minecraft/kubejs/server_scripts/fusion.js/plasma_nexus.js
@@ -7,7 +7,7 @@ ServerEvents.recipes(event => {
     )
     .itemOutputs("1x kubejs:energized_quantum_anomaly")
     .circuit(2)
-    .duration(20 * 323)
+    .duration(20 * 192)
     .EUt(GTValues.VA[GTValues.UXV])
 
   event.recipes.gtceu.plasma_nexus("quantum_anomaly")
@@ -15,6 +15,6 @@ ServerEvents.recipes(event => {
     .inputFluids(Fluid.of("gtceu:eternity", 20))
     .itemOutputs(Item.of("kubejs:quantum_anomaly", 2))
     .circuit(1)
-    .duration(20 * 323)
+    .duration(20 * 192)
     .EUt(GTValues.VA[GTValues.UXV])
 })

--- a/.minecraft/kubejs/server_scripts/mainlines/gregification.js
+++ b/.minecraft/kubejs/server_scripts/mainlines/gregification.js
@@ -236,7 +236,7 @@ ServerEvents.recipes(sog => {
         .itemInputs('8x kubejs:space_time_heavy_plating', 'gtceu:uiv_fluid_regulator')
         .itemOutputs('kubejs:dimensional_pump_module')
         .EUt(32)
-        .circuit(8)
+        .circuit(6)
         sog.recipes.gtceu.assembler('trascendental_space_time_casing')
         .itemInputs('16x kubejs:space_time_heavy_plating')
         .itemOutputs('kubejs:trascendental_space_time_casing')


### PR DESCRIPTION
- change the dimensional pumping module to use the 6th circuit instead of 8th, making the trascendental space time casing be craftable