### PR TITLE
Neutronium Credit recipe and custom coil fixes

### DIFF
--- a/.minecraft/kubejs/server_scripts/multiblocks.js
+++ b/.minecraft/kubejs/server_scripts/multiblocks.js
@@ -389,6 +389,12 @@ event.recipes.gtceu.atomiccompressor('atomically_compressed_neutronium_credit')
     .itemOutputs('kubejs:atomically_compressed_neutronium_credit')
     .duration(20)
     .EUt(GTValues.VA[GTValues.UEV]);
+event.recipes.gtceu.atomiccompressor('neutronium_credit')
+    .itemInputs('65536x gtceu:cupronickel_ingot')
+    .inputFluids('gtceu:neutronium 9216')
+    .itemOutputs('gtmutils:neutronium_credit')
+    .duration(100)
+    .EUt(GTValues.VA[GTValues.UHV]);
 
 event.recipes.gtceu.svs('singularitysteel')
     .itemInputs('1024x gtceu:steel_ingot')

--- a/.minecraft/kubejs/startup_scripts/itemregistry.js
+++ b/.minecraft/kubejs/startup_scripts/itemregistry.js
@@ -547,12 +547,12 @@ StartupEvents.registry('block', sog => {
         .tagBlock('forge:mineable/wrench')
 
 
-        // C O I L S
+    // C O I L S
     sog.create('atomic_alloy_coil_block', 'gtceu:coil')
         .temperature(12500)
-        .level(9)
-        .energyDiscount(16) // 
-        .tier(9)
+        .level(32) //this is the multismelter parallel amount. The math is parallel = (level * 32)
+        .energyDiscount(32) // this is the energy discount theres some esoteric math behind it but if you match it with level it will be fine
+        .tier(9) //This is the cracker and pyrolyse oven stat. pyrolyse is 50% * (tier + 1). Cracker is -10% * (tier + 1)
         .textureAll('kubejs:block/atomic/coil')
         .hardness(5)
         .requiresTool(true)
@@ -560,9 +560,9 @@ StartupEvents.registry('block', sog => {
         .tagBlock('forge:mineable/wrench')
     sog.create('resonant_essence_coil_block', 'gtceu:coil')
         .temperature(13500)
-        .level(15)
+        .level(64)
         .energyDiscount(250) // 
-        .tier(9.5)
+        .tier(10)
         .textureAll('kubejs:block/coils/machine_coil_resonant_essence')
         .hardness(5)
         .requiresTool(true)
@@ -570,18 +570,18 @@ StartupEvents.registry('block', sog => {
         .tagBlock('forge:mineable/wrench')
     sog.create('awakened_draconium_coil_block', 'gtceu:coil')
         .temperature(15500)
-        .level(16)
+        .level(128)
         .energyDiscount(300) // 
-        .tier(10)
+        .tier(11)
         .coilMaterial(() => GTMaterials.get('awakened_draconium'))
         .textureAll('kubejs:block/coils/machine_coil_awakened_draconium')
         .hardness(5)
         .requiresTool(true)
         .soundType('metal')
         .tagBlock('forge:mineable/wrench')
-        sog.create('infinity_coil_block', 'gtceu:coil')
+    sog.create('infinity_coil_block', 'gtceu:coil')
         .temperature(19950)
-        .level(99)
+        .level(1024)
         .energyDiscount(999) // 
         .tier(99)
         .coilMaterial(() => GTMaterials.get('infinity'))


### PR DESCRIPTION
Adds a recipe to the Atomic Compressor for neutronium credits:

- 65536 cupronickel
- 9216 mB neutronium
- UHV tier

Changes Custom coil values to give parallels that are in line with the tiers they are unlocked at:

- Atomic Alloy: 1024
- Resonant Essence: 2048
- Awakened Draconium: 4096
- Infinity: 32768