### PR TITLE
Bring back the quest rewards that aren't "1 Doge Coin" from pre-1.4

### DIFF
--- a/.minecraft/config/ftbquests/quests/chapters/tier_05__steam.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_05__steam.snbt
@@ -102,11 +102,33 @@
 				"3A8A7FC9A7F0814B"
 			]
 			id: "46EEB11B27AF0BBC"
-			rewards: [{
-				id: "1C9D49BE765BF6A4"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 3
+					id: "1C9D49BE765BF6A4"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+				{
+					id: "36DD7218AAB56419"
+					item: {
+						Count: 1
+						id: "trophymanager:trophy"
+						tag: {
+							BaseBlock: "minecraft:smooth_stone_slab"
+							Name: "First Diamond Trophy"
+							OffsetY: 0.55d
+							Scale: 0.75d
+							TrophyItem: {
+								Count: 1.0d
+								id: "minecraft:diamond"
+							}
+							TrophyType: "item"
+						}
+					}
+					type: "item"
+				}
+			]
 			subtitle: "144 Coal = Diamond"
 			tasks: [{
 				id: "5E7A6E47B9A32E5E"
@@ -142,11 +164,24 @@
 			]
 			icon: "gtceu:coke_oven"
 			id: "41F3D8A51709C22B"
-			rewards: [{
-				id: "3BDCAE1B4F958A82"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					id: "497432BBF7400B1A"
+					item: "gtceu:coke_block"
+					type: "item"
+				}
+				{
+					count: 5
+					id: "5FDD5962776A71DA"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+				{
+					id: "7357F29474C92BD5"
+					item: "gtceu:terminal"
+					type: "item"
+				}
+			]
 			shape: "gear"
 			size: 1.5d
 			subtitle: "Sidequests"
@@ -177,6 +212,7 @@
 			icon: "gtceu:primitive_blast_furnace"
 			id: "6B67E665F9D2B062"
 			rewards: [{
+				count: 5
 				id: "5FDD5962776A71DA"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -208,6 +244,7 @@
 			description: ["You have multiple PBFs, right? :D"]
 			id: "31E750DDB33FE642"
 			rewards: [{
+				count: 5
 				id: "11AD72CF7C1D21C8"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -274,6 +311,7 @@
 			icon: "watersources:water_source_tier_1"
 			id: "0291490F6A1806BF"
 			rewards: [{
+				count: 3
 				id: "6CE24D37FB0901E8"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -493,11 +531,19 @@
 			]
 			description: ["I sure hope you're batch crafting everything, else it's not looking good for you."]
 			id: "47F08B64D8FA018F"
-			rewards: [{
-				id: "4010DD360EDDB6D6"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					id: "2446F9A4F74150A4"
+					item: "jecalculation:item_calculator_craft"
+					type: "item"
+				}
+				{
+					count: 5
+					id: "4010DD360EDDB6D6"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+			]
 			shape: "gear"
 			size: 2.0d
 			tasks: [{
@@ -580,6 +626,7 @@
 			id: "71A1EDA69A1E26F8"
 			optional: true
 			rewards: [{
+				count: 3
 				id: "615607CD3B349EA4"
 				item: "gtmutils:doge_coin"
 				type: "item"

--- a/.minecraft/config/ftbquests/quests/chapters/tier_0__stone.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_0__stone.snbt
@@ -66,11 +66,19 @@
 		{
 			dependencies: ["2E3BA53EE6679354"]
 			id: "451B35D595D41780"
-			rewards: [{
-				id: "6BF228699EF86494"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 8
+					id: "647EE68F7DD6DC47"
+					item: "minecraft:gravel"
+					type: "item"
+				}
+				{
+					id: "6BF228699EF86494"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+			]
 			subtitle: "Expand your little island plz"
 			tasks: [{
 				id: "3C4E570743F1CEB0"
@@ -89,11 +97,18 @@
 		{
 			dependencies: ["451B35D595D41780"]
 			id: "14FFC5F39A9A2285"
-			rewards: [{
-				id: "498F90CD17693C65"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					id: "4E06CA25171379F8"
+					item: "minecraft:flint"
+					type: "item"
+				}
+				{
+					id: "498F90CD17693C65"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+			]
 			subtitle: "Mine the gravel"
 			tasks: [{
 				count: 5L
@@ -151,6 +166,7 @@
 			]
 			id: "3539E7FC4963D6BD"
 			rewards: [{
+				count: 5
 				id: "575C10CAB3F11A99"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -173,11 +189,18 @@
 			]
 			icon: "minecraft:string"
 			id: "2611ADAFB9634874"
-			rewards: [{
-				id: "2FA743D16715970A"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					id: "7B257DFD24E72770"
+					item: "minecraft:string"
+					type: "item"
+				}
+				{
+					id: "2FA743D16715970A"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+			]
 			tasks: [
 				{
 					id: "36A1282FA2217307"
@@ -204,6 +227,7 @@
 			icon: "minecraft:white_bed"
 			id: "5F13A8C4D2D642B0"
 			rewards: [{
+				count: 2
 				id: "24142B3CCE3CC0A3"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -321,11 +345,19 @@
 			}
 			id: "5F05388789A2A4B8"
 			progression_mode: "flexible"
-			rewards: [{
-				id: "16B1471A64BD1CC5"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 8
+					id: "788318C34708217F"
+					item: "gtceu:wrought_iron_ingot"
+					type: "item"
+				}
+				{
+					id: "16B1471A64BD1CC5"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+			]
 			subtitle: "Any tool?"
 			tasks: [
 				{
@@ -617,11 +649,18 @@
 				"This is a linked quest to the steam age chapter, so when you complete this you will automatically start the Tier 0.5-"
 			]
 			id: "68357F7109A5645C"
-			rewards: [{
-				id: "7906A6B5078203CA"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					id: "2D52191B54F4619B"
+					item: "usclb:clipboard"
+					type: "item"
+				}
+				{
+					id: "7906A6B5078203CA"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+			]
 			shape: "hexagon"
 			size: 1.5d
 			subtitle: "We steamin' with this one"

--- a/.minecraft/config/ftbquests/quests/chapters/tier_1__lv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_1__lv.snbt
@@ -36,6 +36,7 @@
 			dependencies: ["16AF5E167963CD5E"]
 			id: "600C9FE63DAFB132"
 			rewards: [{
+				count: 3
 				id: "0F6C8181CB7835C5"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -293,6 +294,7 @@
 			icon: "gtceu:raw_diamond"
 			id: "11F178FE7717ACD2"
 			rewards: [{
+				count: 3
 				id: "011D8051C2C235D6"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -475,11 +477,33 @@
 			description: ["Cool multiblock, you might wanna make even 2 or more of those as you're also gonna need it for the circuit, not only the aluminium."]
 			icon: "gtceu:electric_blast_furnace"
 			id: "507C474A64173290"
-			rewards: [{
-				id: "3AE42DD900668DA3"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 5
+					id: "3AE42DD900668DA3"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+				{
+					id: "4F3A850440AD3B78"
+					item: {
+						Count: 1
+						id: "trophymanager:trophy"
+						tag: {
+							BaseBlock: "minecraft:smooth_stone_slab"
+							Name: "First EBF"
+							OffsetY: 0.55d
+							Scale: 0.75d
+							TrophyItem: {
+								Count: 1.0d
+								id: "gtceu:electric_blast_furnace"
+							}
+							TrophyType: "item"
+						}
+					}
+					type: "item"
+				}
+			]
 			shape: "gear"
 			size: 1.5d
 			subtitle: "Big milestone go brrrr"
@@ -862,6 +886,7 @@
 			description: ["Did you passive aluminium ingots???"]
 			id: "2F459E86E600C4DD"
 			rewards: [{
+				count: 5
 				id: "06022AE3F5D7972D"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -926,6 +951,7 @@
 			]
 			id: "66079F4565A6B631"
 			rewards: [{
+				count: 5
 				id: "7E07B2CD13CC7D32"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -964,27 +990,20 @@
 				}
 			}
 			id: "4F38FDE69E161339"
-			rewards: [
-				{
-					id: "3FCB443B10A56296"
-					item: "gtmutils:doge_coin"
-					type: "item"
-				}
-				{
-					id: "4324EC7BBDD2D1A4"
-					item: {
-						Count: 1
-						id: "hostilenetworks:data_model"
-						tag: {
-							data_model: {
-								data: 6
-								id: "hostilenetworks:squid"
-							}
+			rewards: [{
+				id: "549FB3E610A68F36"
+				item: {
+					Count: 1
+					id: "hostilenetworks:data_model"
+					tag: {
+						data_model: {
+							data: 6
+							id: "hostilenetworks:squid"
 						}
 					}
-					type: "item"
 				}
-			]
+				type: "item"
+			}]
 			subtitle: "Peaceful Friendly"
 			tasks: [
 				{
@@ -1062,6 +1081,7 @@
 			]
 			id: "4F312669D4434DF1"
 			rewards: [{
+				count: 2
 				id: "6E9ACC1B2CC75713"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1126,6 +1146,7 @@
 			dependencies: ["2A06152CD35AEB43"]
 			id: "400998B80287CE93"
 			rewards: [{
+				count: 3
 				id: "39D67D6C8BB4D25C"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1143,6 +1164,7 @@
 			dependencies: ["35BEC4D7A3A6B971"]
 			id: "1E8BE05E017C47AE"
 			rewards: [{
+				count: 3
 				id: "414F0CD7328BE407"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1160,6 +1182,7 @@
 			dependencies: ["0CC37A2971DEEB69"]
 			id: "0D91D32DEA66E74B"
 			rewards: [{
+				count: 3
 				id: "516E32B4E37E90DE"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1197,6 +1220,7 @@
 			description: ["See items that you have right next to the crafting slots!"]
 			id: "34A90C36E9A8A51C"
 			rewards: [{
+				count: 3
 				id: "0EE5F4E8F3FEE04E"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1374,27 +1398,20 @@
 			}
 			id: "0718B686D7E82E27"
 			optional: true
-			rewards: [
-				{
-					id: "08EF196B204C1F48"
-					item: "gtmutils:doge_coin"
-					type: "item"
-				}
-				{
-					id: "37D9F5F8EE0FCCF8"
-					item: {
-						Count: 1
-						id: "hostilenetworks:data_model"
-						tag: {
-							data_model: {
-								data: 6
-								id: "hostilenetworks:spider"
-							}
+			rewards: [{
+				id: "34701CBF46512118"
+				item: {
+					Count: 1
+					id: "hostilenetworks:data_model"
+					tag: {
+						data_model: {
+							data: 6
+							id: "hostilenetworks:spider"
 						}
 					}
-					type: "item"
 				}
-			]
+				type: "item"
+			}]
 			tasks: [
 				{
 					consume_items: true

--- a/.minecraft/config/ftbquests/quests/chapters/tier_2__mv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_2__mv.snbt
@@ -202,27 +202,20 @@
 				}
 			}
 			id: "53E330337358D8DC"
-			rewards: [
-				{
-					id: "4BB3EFF05A2E3292"
-					item: "gtmutils:doge_coin"
-					type: "item"
-				}
-				{
-					id: "5FF87D61A3CDB454"
-					item: {
-						Count: 1
-						id: "hostilenetworks:data_model"
-						tag: {
-							data_model: {
-								data: 6
-								id: "hostilenetworks:witch"
-							}
+			rewards: [{
+				id: "12E0E9CD8A8A734F"
+				item: {
+					Count: 1
+					id: "hostilenetworks:data_model"
+					tag: {
+						data_model: {
+							data: 6
+							id: "hostilenetworks:witch"
 						}
 					}
-					type: "item"
 				}
-			]
+				type: "item"
+			}]
 			tasks: [
 				{
 					consume_items: true
@@ -781,11 +774,18 @@
 				"You get an orange lens as a gift since you can't craft the ones that don't have an ore counterpart yet!"
 			]
 			id: "47F6AD489D5C7003"
-			rewards: [{
-				id: "3333C3A61E4D0C49"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					id: "03F563B018534E52"
+					item: "gtceu:orange_glass_lens"
+					type: "item"
+				}
+				{
+					id: "3333C3A61E4D0C49"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+			]
 			tasks: [
 				{
 					id: "1D23C9D2EDAFF976"
@@ -947,6 +947,7 @@
 			]
 			id: "1AD136F25B306F75"
 			rewards: [{
+				count: 5
 				id: "251B4AC4AEA4FF10"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1047,12 +1048,7 @@
 			optional: true
 			rewards: [
 				{
-					id: "5532941BCB9F7563"
-					item: "gtmutils:doge_coin"
-					type: "item"
-				}
-				{
-					id: "2C97F3020C21D43F"
+					id: "7E4FE85146C00A89"
 					item: {
 						Count: 1
 						id: "gtceu:prospector.luv"
@@ -1060,6 +1056,12 @@
 							Charge: 1000000000L
 						}
 					}
+					type: "item"
+				}
+				{
+					count: 5
+					id: "5532941BCB9F7563"
+					item: "gtmutils:doge_coin"
 					type: "item"
 				}
 			]
@@ -1092,11 +1094,33 @@
 				"What route did you use?"
 			]
 			id: "26C62836B41D0095"
-			rewards: [{
-				id: "03EDBEB68F72C4CD"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 5
+					id: "03EDBEB68F72C4CD"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+				{
+					id: "64FB6F55FF9BAF2E"
+					item: {
+						Count: 1
+						id: "trophymanager:trophy"
+						tag: {
+							BaseBlock: "minecraft:smooth_stone_slab"
+							Name: "Polyethylene!"
+							OffsetY: 0.55d
+							Scale: 0.75d
+							TrophyItem: {
+								Count: 1.0d
+								id: "gtceu:polyethylene_foil"
+							}
+							TrophyType: "item"
+						}
+					}
+					type: "item"
+				}
+			]
 			subtitle: "AKA go to hell v.alpha"
 			tasks: [{
 				id: "7AEEE37CC3A64D6C"
@@ -1166,6 +1190,7 @@
 			]
 			id: "41D39163C8154F7C"
 			rewards: [{
+				count: 5
 				id: "38ABC2EA42ED13AA"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1189,6 +1214,7 @@
 			description: ["Welcome to HV"]
 			id: "331055377E5032C8"
 			rewards: [{
+				count: 2
 				id: "06AE87EC7C86B220"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1218,27 +1244,20 @@
 			}
 			id: "733971C42894950A"
 			optional: true
-			rewards: [
-				{
-					id: "6B3EE059B9EA81FB"
-					item: "gtmutils:doge_coin"
-					type: "item"
-				}
-				{
-					id: "47EFCFA41B8E16E0"
-					item: {
-						Count: 1
-						id: "hostilenetworks:data_model"
-						tag: {
-							data_model: {
-								data: 6
-								id: "hostilenetworks:slime"
-							}
+			rewards: [{
+				id: "6F82D29A18DDD0B8"
+				item: {
+					Count: 1
+					id: "hostilenetworks:data_model"
+					tag: {
+						data_model: {
+							data: 6
+							id: "hostilenetworks:slime"
 						}
 					}
-					type: "item"
 				}
-			]
+				type: "item"
+			}]
 			tasks: [
 				{
 					consume_items: true
@@ -1303,6 +1322,7 @@
 			]
 			id: "5DD037064DB51B4D"
 			rewards: [{
+				count: 2
 				id: "058A03EA631F5F36"
 				item: "gtmutils:doge_coin"
 				type: "item"

--- a/.minecraft/config/ftbquests/quests/chapters/tier_3__hv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_3__hv.snbt
@@ -209,11 +209,6 @@
 			optional: true
 			rewards: [
 				{
-					id: "403C2EC28DDC3F27"
-					item: "gtmutils:doge_coin"
-					type: "item"
-				}
-				{
 					id: "57D9F2973FF09FED"
 					item: {
 						Count: 1
@@ -225,6 +220,17 @@
 							}
 						}
 					}
+					type: "item"
+				}
+				{
+					count: 4
+					id: "32AA8D537EA47A72"
+					item: "minecraft:ender_pearl"
+					type: "item"
+				}
+				{
+					id: "403C2EC28DDC3F27"
+					item: "gtmutils:doge_coin"
 					type: "item"
 				}
 			]
@@ -340,6 +346,7 @@
 			icon: "gtceu:cleanroom"
 			id: "63367A2F12D66CC4"
 			rewards: [{
+				count: 5
 				id: "6ED84EAD843B310D"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -416,11 +423,6 @@
 			optional: true
 			rewards: [
 				{
-					id: "5F8B4543A90F666F"
-					item: "gtmutils:doge_coin"
-					type: "item"
-				}
-				{
 					id: "5134251DDB1F574E"
 					item: {
 						Count: 1
@@ -432,6 +434,11 @@
 							}
 						}
 					}
+					type: "item"
+				}
+				{
+					id: "5F8B4543A90F666F"
+					item: "gtmutils:doge_coin"
 					type: "item"
 				}
 			]
@@ -542,11 +549,41 @@
 		{
 			dependencies: ["10F5CE8D2BFA4A96"]
 			id: "51EB75969C2A340E"
-			rewards: [{
-				id: "1216475D0DB87CCC"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					id: "61513285AB6236EA"
+					item: {
+						Count: 1
+						id: "minecraft:enchanted_book"
+						tag: {
+							StoredEnchantments: [{
+								id: "minecraft:infinity"
+								lvl: 1s
+							}]
+						}
+					}
+					type: "item"
+				}
+				{
+					id: "7859E23742A28E87"
+					item: {
+						Count: 1
+						id: "minecraft:enchanted_book"
+						tag: {
+							StoredEnchantments: [{
+								id: "minecraft:power"
+								lvl: 5s
+							}]
+						}
+					}
+					type: "item"
+				}
+				{
+					id: "1216475D0DB87CCC"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+			]
 			tasks: [{
 				id: "2863231A715876B8"
 				item: "exdeorum:end_cake"
@@ -812,6 +849,7 @@
 			]
 			id: "0AA191C4D0B6682D"
 			rewards: [{
+				count: 5
 				id: "0F798ECAB57E137E"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1001,6 +1039,7 @@
 			]
 			id: "2A476DB7A53D97B2"
 			rewards: [{
+				count: 5
 				id: "6A40B0A997E28EAF"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1026,11 +1065,33 @@
 			]
 			icon: "ae2:controller"
 			id: "7CC9AEC1E514D0DE"
-			rewards: [{
-				id: "2D0C3496966FE849"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 5
+					id: "2D0C3496966FE849"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+				{
+					id: "2CBA1C59B076C73F"
+					item: {
+						Count: 1
+						id: "trophymanager:trophy"
+						tag: {
+							BaseBlock: "ae2:smooth_sky_stone_slab"
+							Name: "Applied Energistics 2"
+							OffsetY: 0.55d
+							Scale: 0.75d
+							TrophyItem: {
+								Count: 1.0d
+								id: "ae2:controller"
+							}
+							TrophyType: "item"
+						}
+					}
+					type: "item"
+				}
+			]
 			size: 1.5d
 			tasks: [{
 				id: "00D7707155874136"
@@ -1248,6 +1309,7 @@
 			description: ["LETS GOOOOOOOOOOOOOOOOOO"]
 			id: "0A81DBA4F2D33338"
 			rewards: [{
+				count: 5
 				id: "7E6A912808D45657"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1274,11 +1336,41 @@
 				}
 			}
 			id: "22E32E4A8A6A927E"
-			rewards: [{
-				id: "1830FD1421E050F3"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					id: "37477A3E699A61DF"
+					item: {
+						Count: 1
+						id: "hostilenetworks:data_model"
+						tag: {
+							data_model: {
+								data: 6
+								id: "hostilenetworks:ender_dragon"
+							}
+						}
+					}
+					type: "item"
+				}
+				{
+					id: "67B2F8AB3B728D77"
+					item: {
+						Count: 1
+						id: "hostilenetworks:data_model"
+						tag: {
+							data_model: {
+								data: 6
+								id: "hostilenetworks:ender_dragon"
+							}
+						}
+					}
+					type: "item"
+				}
+				{
+					id: "1830FD1421E050F3"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+			]
 			tasks: [
 				{
 					id: "6BBCC8F5F9E57007"

--- a/.minecraft/config/ftbquests/quests/chapters/tier_5__iv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_5__iv.snbt
@@ -151,6 +151,7 @@
 			dependencies: ["5D5FA5429F87E942"]
 			id: "7CFBD6D6165E827D"
 			rewards: [{
+				count: 2
 				id: "1A41BD7CEB4DDDA8"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -296,6 +297,7 @@
 			description: ["The main LuV material."]
 			id: "3373B55C96DFFC1C"
 			rewards: [{
+				count: 3
 				id: "573D0351A179E378"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -679,6 +681,7 @@
 			description: ["Another big milestone, this incredibly strong synthetic fiber is gonna be used for almost everything from now on, so I hope you made it sustainable to mass produce! :D"]
 			id: "62704CC3038F1B20"
 			rewards: [{
+				count: 3
 				id: "75DD08D5DDA48CC4"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1332,6 +1335,7 @@
 			dependencies: ["1AEEFC47BF7F67C8"]
 			id: "69ACAFA6A0D18671"
 			rewards: [{
+				count: 5
 				id: "47EB761BD9F5EC37"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1355,6 +1359,7 @@
 			description: ["Welcome to LuV"]
 			id: "34112DEEBBD82652"
 			rewards: [{
+				count: 6
 				id: "3840534A095BB0E7"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1587,11 +1592,33 @@
 				"You make this by placing some star matter in a crystalization chamber with an extruder mold of star, but the reason to why you use this big boi instead of an autoclave, is because of the overclocking."
 			]
 			id: "3F0D5B357A418240"
-			rewards: [{
-				id: "1BCAC2A0DC5B6874"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 5
+					id: "1BCAC2A0DC5B6874"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+				{
+					id: "4E7812CD82DA1943"
+					item: {
+						Count: 1
+						id: "trophymanager:trophy"
+						tag: {
+							BaseBlock: "ae2:smooth_sky_stone_slab"
+							Name: "Nether Stars!"
+							OffsetY: 0.55d
+							Scale: 0.75d
+							TrophyItem: {
+								Count: 1.0d
+								id: "minecraft:nether_star"
+							}
+							TrophyType: "item"
+						}
+					}
+					type: "item"
+				}
+			]
 			shape: "octagon"
 			size: 1.5d
 			tasks: [{

--- a/.minecraft/config/ftbquests/quests/chapters/tier_6__luv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_6__luv.snbt
@@ -24,11 +24,22 @@
 				"And you will produce life essence on gregtech machines aswell as altar tiers as multiblock machines."
 			]
 			id: "70DAF76189CCF436"
-			rewards: [{
-				id: "641089D06632AF2E"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					id: "610F584F5BA9C0CC"
+					item: {
+						Count: 1
+						id: "bloodmagic:sacrificialdagger"
+						tag: { }
+					}
+					type: "item"
+				}
+				{
+					id: "641089D06632AF2E"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+			]
 			subtitle: "Kinda"
 			tasks: [{
 				id: "574E18E668E81408"
@@ -183,6 +194,7 @@
 			]
 			id: "545751E4174E83B7"
 			rewards: [{
+				count: 2
 				id: "32EEBB746E93CBB5"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -277,6 +289,7 @@
 			dependencies: ["4E7E9E3C0D2E77B3"]
 			id: "60993AD55C1FE256"
 			rewards: [{
+				count: 3
 				id: "1588F2DA4BAE430D"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -329,6 +342,7 @@
 			dependencies: ["02888AAD173AEED0"]
 			id: "282CE68698C0C23B"
 			rewards: [{
+				count: 4
 				id: "2989193858DF63A0"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -369,6 +383,7 @@
 			]
 			id: "0FFD1907A9ADF583"
 			rewards: [{
+				count: 5
 				id: "401909E8B46A9BC4"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1007,6 +1022,7 @@
 			dependencies: ["52D8C84D4C6E60AA"]
 			id: "7DBE783F04F59ABB"
 			rewards: [{
+				count: 3
 				id: "5805EF04C63AF128"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1030,11 +1046,33 @@
 				"Now go mine for some ostrum to get the globe."
 			]
 			id: "5DFB4F932F44C748"
-			rewards: [{
-				id: "7C1C4D2BEC996FF1"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 3
+					id: "7C1C4D2BEC996FF1"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+				{
+					id: "223C6BE6CBA02C7F"
+					item: {
+						Count: 1
+						id: "trophymanager:trophy"
+						tag: {
+							BaseBlock: "ae2:smooth_sky_stone_slab"
+							Name: "Tier 2 Rocket"
+							OffsetY: 0.75d
+							Scale: 3
+							TrophyItem: {
+								Count: 1.0d
+								id: "ad_astra:tier_2_rocket"
+							}
+							TrophyType: "item"
+						}
+					}
+					type: "item"
+				}
+			]
 			shape: "none"
 			size: 3.0d
 			tasks: [{
@@ -1344,6 +1382,7 @@
 			]
 			id: "5C47B681BACC22D4"
 			rewards: [{
+				count: 2
 				id: "615789D2898F7297"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1466,6 +1505,7 @@
 			dependencies: ["13FF0019F6DE6AFE"]
 			id: "49EC7260E8AACB05"
 			rewards: [{
+				count: 5
 				id: "0F7B6315C954245A"
 				item: "gtmutils:doge_coin"
 				type: "item"

--- a/.minecraft/config/ftbquests/quests/chapters/tier_7__zpm.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_7__zpm.snbt
@@ -44,11 +44,32 @@
 				"These need to heat up every time you change the recipe, so make sure you have those running passively, not on-demand."
 			]
 			id: "387BFDB3C6162B0B"
-			rewards: [{
-				id: "31F31F47264BF20C"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					id: "31F31F47264BF20C"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+				{
+					id: "7EA4C0B7D5315FCA"
+					item: {
+						Count: 1
+						id: "trophymanager:trophy"
+						tag: {
+							BaseBlock: "ae2:smooth_sky_stone_slab"
+							Name: "Fusion Reactor"
+							OffsetY: 0.55d
+							Scale: 0.75d
+							TrophyItem: {
+								Count: 1.0d
+								id: "gtceu:luv_fusion_reactor"
+							}
+							TrophyType: "item"
+						}
+					}
+					type: "item"
+				}
+			]
 			subtitle: "The Donut age"
 			tasks: [{
 				id: "366002194E9947D5"
@@ -156,6 +177,7 @@
 			]
 			id: "60E68576221A5CB2"
 			rewards: [{
+				count: 3
 				id: "1EA6D101B2F5006A"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -255,6 +277,7 @@
 			]
 			id: "552AA21A1848CEDF"
 			rewards: [{
+				count: 5
 				id: "76AB412C2C84D0AE"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -477,6 +500,7 @@
 			description: ["These are gonna be really slow and painful to get right now, so work towards getting the next UV circuits, which won't need an entire assembly line to craft!"]
 			id: "5145593BA83D0FDF"
 			rewards: [{
+				count: 5
 				id: "472A8F1CCE6E5854"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -704,6 +728,7 @@
 			description: [""]
 			id: "125789E676E22B37"
 			rewards: [{
+				count: 6
 				id: "00ADB98C99692A0B"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -744,6 +769,7 @@
 			icon: "gtceu:creative_data_access_hatch"
 			id: "1DA514DF999B91D1"
 			rewards: [{
+				count: 10
 				id: "6A7422D41EEB0BF8"
 				item: "gtmutils:doge_coin"
 				type: "item"

--- a/.minecraft/config/ftbquests/quests/chapters/tier_8__uv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_8__uv.snbt
@@ -536,6 +536,7 @@
 			dependencies: ["4DA842D406AADCF8"]
 			id: "3D13A7A4FD812614"
 			rewards: [{
+				count: 5
 				id: "6E308989BE590886"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -620,11 +621,33 @@
 			]
 			icon: "gtceu:atomicforge"
 			id: "78AD69A43E7C24D4"
-			rewards: [{
-				id: "76B2CB5C2753F5C3"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 15
+					id: "76B2CB5C2753F5C3"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+				{
+					id: "28C9931AA569C698"
+					item: {
+						Count: 1
+						id: "trophymanager:trophy"
+						tag: {
+							BaseBlock: "antiblocksrechiseled:slab_black"
+							Name: "Atomic Forge"
+							OffsetY: 0.55d
+							Scale: 0.75d
+							TrophyItem: {
+								Count: 1.0d
+								id: "gtceu:atomicforge"
+							}
+							TrophyType: "item"
+						}
+					}
+					type: "item"
+				}
+			]
 			shape: "octagon"
 			size: 1.5d
 			subtitle: "Very expensive."
@@ -675,6 +698,7 @@
 			]
 			id: "0AD942FF650E56A4"
 			rewards: [{
+				count: 15
 				id: "6B5764B3232B35A6"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -732,6 +756,7 @@
 			]
 			id: "14DA1644C84FC058"
 			rewards: [{
+				count: 5
 				id: "0612F9BE9069006B"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1109,6 +1134,7 @@
 			description: ["The best mainframe, right?..."]
 			id: "63E8F8D63212D1F0"
 			rewards: [{
+				count: 10
 				id: "3A68B65AAE136165"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1170,6 +1196,7 @@
 			description: ["Get prepared, you are gonna need a lot of singularities."]
 			id: "02FB67793FFB1B16"
 			rewards: [{
+				count: 3
 				id: "54E20817A0744A20"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1301,6 +1328,7 @@
 			]
 			id: "3EB096642664FBB1"
 			rewards: [{
+				count: 20
 				id: "359E180263E460E2"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1321,6 +1349,7 @@
 			dependencies: ["4C15C82E0E38B70A"]
 			id: "3C17416E9BA5BFEC"
 			rewards: [{
+				count: 5
 				id: "01AB0F69FC1A9BDE"
 				item: "gtmutils:doge_coin"
 				type: "item"

--- a/.minecraft/config/ftbquests/quests/chapters/tier_9__uhv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_9__uhv.snbt
@@ -31,6 +31,7 @@
 			]
 			id: "1ECBFC16CA338458"
 			rewards: [{
+				count: 2
 				id: "710A39AA8093D930"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -48,6 +49,7 @@
 			description: ["Yipii, the start of the singularity line. Which ironically stars with a singularity."]
 			id: "18812DC1665ACB5C"
 			rewards: [{
+				count: 2
 				id: "1830A6506B5DCED0"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -65,6 +67,7 @@
 			description: ["Now you are probably wondering how does this requiere UHV right?. Just wait."]
 			id: "5CA644465CF0DC97"
 			rewards: [{
+				count: 2
 				id: "6E4A2E4D803BDE26"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -80,11 +83,19 @@
 		{
 			dependencies: ["02FB67793FFB1B16"]
 			id: "54696AD3E7A21F00"
-			rewards: [{
-				id: "4654C2CA90B92837"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					id: "73D89EC75F09804A"
+					item: "gtceu:wetware_processor_mainframe"
+					type: "item"
+				}
+				{
+					count: 2
+					id: "4654C2CA90B92837"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+			]
 			subtitle: "Don't try seeing the EMI tree..."
 			tasks: [{
 				id: "2555049AF3B694A7"
@@ -99,6 +110,7 @@
 			description: ["This is quantum energy... contained in a cell."]
 			id: "164DE1203C8BEE1B"
 			rewards: [{
+				count: 2
 				id: "24918C4680D3637D"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -116,6 +128,7 @@
 			description: ["This uses a hell ton of radon, so I'd recommend getting the atmospheric collector to gather lots of end air "]
 			id: "0608F68656DC2B06"
 			rewards: [{
+				count: 2
 				id: "2299DCDD49E47C36"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -133,6 +146,7 @@
 			description: ["What a crazy recipe isn't it? This is actually the most expensive item from vanilla GregTech."]
 			id: "54747FBD8456EE8A"
 			rewards: [{
+				count: 2
 				id: "4DE350C1E5CD2164"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -151,6 +165,7 @@
 			dependencies: ["0608F68656DC2B06"]
 			id: "3BCC5333E39DCDB5"
 			rewards: [{
+				count: 2
 				id: "28DA9BD77C4A6CDB"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -167,11 +182,45 @@
 			dependencies: ["3BCC5333E39DCDB5"]
 			description: ["What? You can get draconium dust by killing the ender dragon."]
 			id: "4FF7EFE37A9BD3AE"
-			rewards: [{
-				id: "6D8791497C04E483"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 2
+					id: "6D8791497C04E483"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+				{
+					id: "3D7A0554B1AA7D1E"
+					item: {
+						Count: 1
+						id: "gtceu:neutronium_scythe"
+						tag: {
+							DisallowContainerItem: 0b
+							GT.Behaviours: {
+								AoEColumn: 2
+								AoELayer: 2
+								AoERow: 2
+								MaxAoEColumn: 2
+								MaxAoELayer: 2
+								MaxAoERow: 2
+								RelocateMinedBlocks: 1b
+								RelocateMobDrops: 1b
+							}
+							GT.Tool: {
+								AttackDamage: 105.0f
+								AttackSpeed: -2.5f
+								Damage: 0
+								HarvestLevel: 6
+								MaxDamage: 196604
+								ToolSpeed: 184.0f
+							}
+							HideFlags: 2
+							Unbreakable: 1b
+						}
+					}
+					type: "item"
+				}
+			]
 			tasks: [{
 				id: "7B1ABC1957380766"
 				item: "draconicevolution:draconium_core"
@@ -184,6 +233,7 @@
 			dependencies: ["4FF7EFE37A9BD3AE"]
 			id: "0379F0315FC8B73F"
 			rewards: [{
+				count: 2
 				id: "6C8EE0CE5DD72698"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -200,6 +250,7 @@
 			dependencies: ["4FF7EFE37A9BD3AE"]
 			id: "49C64FFB6F5EABFC"
 			rewards: [{
+				count: 2
 				id: "615AFE844617D161"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -222,11 +273,19 @@
 			]
 			description: ["Expensive multiblock? Well... try to run this passively."]
 			id: "294190B6FB4C75D9"
-			rewards: [{
-				id: "5DFBDDF0D21E2C01"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 5
+					id: "5DFBDDF0D21E2C01"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+				{
+					id: "1DC193AE5CC715C1"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+			]
 			shape: "octagon"
 			size: 2.0d
 			tasks: [{
@@ -241,6 +300,7 @@
 			dependencies: ["294190B6FB4C75D9"]
 			id: "66C76E2ED346F471"
 			rewards: [{
+				count: 2
 				id: "19F57E5B4C1D1E5E"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -257,6 +317,7 @@
 			dependencies: ["294190B6FB4C75D9"]
 			id: "56EE14CC857B60B3"
 			rewards: [{
+				count: 2
 				id: "0FBB34D0ED3962D0"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -276,6 +337,7 @@
 			]
 			id: "4592FBF524AFDCBF"
 			rewards: [{
+				count: 2
 				id: "786F6361EDB8B49A"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -303,6 +365,7 @@
 			]
 			id: "251FBD9F0A55D451"
 			rewards: [{
+				count: 6
 				id: "3CBAC12E1A15D32B"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -325,6 +388,7 @@
 			description: ["You better passive most of the materials for this, believe me."]
 			id: "680A4BAD1F1289C3"
 			rewards: [{
+				count: 2
 				id: "2BF38C413339AF8C"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -342,6 +406,7 @@
 			dependencies: ["680A4BAD1F1289C3"]
 			id: "695308CFB8D4505C"
 			rewards: [{
+				count: 2
 				id: "51DB73218BBC6627"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -361,6 +426,7 @@
 			]
 			id: "0032181B1C8FC0C2"
 			rewards: [{
+				count: 2
 				id: "32DCE7EA99177128"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -377,6 +443,7 @@
 			dependencies: ["0032181B1C8FC0C2"]
 			id: "27F6A813D963DDF4"
 			rewards: [{
+				count: 6
 				id: "18CD282AD685B5B5"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -396,6 +463,7 @@
 			icon: "extendedcrafting:ultimate_singularity"
 			id: "5FBA0D688D633430"
 			rewards: [{
+				count: 2
 				id: "204BE5CC979A5F0C"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -548,11 +616,33 @@
 				"&7&oand for a lot of other things..&r"
 			]
 			id: "687F155B59B5FC1C"
-			rewards: [{
-				id: "6E61507289EFAD3C"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 16
+					id: "6E61507289EFAD3C"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+				{
+					id: "26EF829AB9342C3C"
+					item: {
+						Count: 1
+						id: "trophymanager:trophy"
+						tag: {
+							BaseBlock: "ad_astra:polished_permafrost_slab"
+							Name: "Eternal Singularity Trophy"
+							OffsetY: 0.55d
+							Scale: 0.75d
+							TrophyItem: {
+								Count: 1.0d
+								id: "avaritia:eternal_singularity"
+							}
+							TrophyType: "item"
+						}
+					}
+					type: "item"
+				}
+			]
 			shape: "none"
 			size: 2.0d
 			subtitle: "What is this power.."
@@ -568,6 +658,7 @@
 			dependencies: ["687F155B59B5FC1C"]
 			id: "6463C37333165A07"
 			rewards: [{
+				count: 2
 				id: "1B1F7F5C13C7D7C1"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -607,6 +698,7 @@
 			dependencies: ["6463C37333165A07"]
 			id: "3935F91B104E894B"
 			rewards: [{
+				count: 2
 				id: "380B8EEEACAEB257"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -629,6 +721,7 @@
 			]
 			id: "519D47C7E8E2B4D2"
 			rewards: [{
+				count: 2
 				id: "29FCE4CD687F05B5"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -654,6 +747,7 @@
 			}
 			id: "59EB0032735E66F6"
 			rewards: [{
+				count: 2
 				id: "671B2FC570971F28"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -716,6 +810,7 @@
 			]
 			id: "67555843799DBDD7"
 			rewards: [{
+				count: 16
 				id: "71D6FBF2DA59B573"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -739,6 +834,7 @@
 			icon: "ad_astra:venus_globe"
 			id: "24E55FA9B85C8F5E"
 			rewards: [{
+				count: 2
 				id: "2B13BF45884866E1"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -757,6 +853,7 @@
 			icon: "ad_astra:mercury_globe"
 			id: "09C67452DFDDA7FD"
 			rewards: [{
+				count: 2
 				id: "5190132044C2D36A"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -774,6 +871,7 @@
 			dependencies: ["09C67452DFDDA7FD"]
 			id: "4D28528655B1AF54"
 			rewards: [{
+				count: 2
 				id: "1EA7EFDFB1A830C7"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -792,6 +890,7 @@
 			description: ["&1Kaemite&r appears as a fluid vein on Mercury. Place some miners!"]
 			id: "31381DE18B522428"
 			rewards: [{
+				count: 2
 				id: "79FA7AE01B0A7627"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -808,6 +907,7 @@
 			dependencies: ["24E55FA9B85C8F5E"]
 			id: "44ECE182566B19C6"
 			rewards: [{
+				count: 2
 				id: "313B1A8E97352301"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -825,6 +925,7 @@
 			dependencies: ["4D28528655B1AF54"]
 			id: "686884CB55C62494"
 			rewards: [{
+				count: 2
 				id: "765A001172BF4B0C"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -844,6 +945,7 @@
 			]
 			id: "1817E22F002CB954"
 			rewards: [{
+				count: 2
 				id: "624285092C57CDCE"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -865,6 +967,7 @@
 			]
 			id: "197C85F8DEFB91AE"
 			rewards: [{
+				count: 2
 				id: "26D97DE690A9B275"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -886,6 +989,7 @@
 			]
 			id: "06100AEBEB6F9616"
 			rewards: [{
+				count: 2
 				id: "10823652CBAB472F"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -902,6 +1006,7 @@
 			dependencies: ["31381DE18B522428"]
 			id: "3ADFF25145B40563"
 			rewards: [{
+				count: 2
 				id: "6A154E4728B65ED0"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -920,11 +1025,18 @@
 				"3ADFF25145B40563"
 			]
 			id: "4AD46A58DA77BD53"
-			rewards: [{
-				id: "707766EBBF9961F0"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					id: "707766EBBF9961F0"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+				{
+					id: "3C0480AACCACBC42"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+			]
 			tasks: [{
 				id: "1D3EA51B102E8C21"
 				item: "kubejs:quantum_casing"
@@ -940,11 +1052,33 @@
 			]
 			description: ["Requires &b27&r eternal singularities."]
 			id: "57AE0E9F60EE1824"
-			rewards: [{
-				id: "032F8AF7E117AA86"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					count: 26
+					id: "032F8AF7E117AA86"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+				{
+					id: "6579D96D880921CA"
+					item: {
+						Count: 1
+						id: "trophymanager:trophy"
+						tag: {
+							BaseBlock: "antiblocksrechiseled:slab_black"
+							Name: "Quantum Space Projector"
+							OffsetY: 0.55d
+							Scale: 0.75d
+							TrophyItem: {
+								Count: 1.0d
+								id: "gtceu:quantum_space_projector"
+							}
+							TrophyType: "item"
+						}
+					}
+					type: "item"
+				}
+			]
 			shape: "octagon"
 			size: 2.0d
 			subtitle: "Quantum Space Projector"
@@ -967,6 +1101,7 @@
 			]
 			id: "6C81DC0AF93DC884"
 			rewards: [{
+				count: 2
 				id: "382EA203A23D6D9D"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -991,6 +1126,7 @@
 			]
 			id: "3EF119D2D7764D6D"
 			rewards: [{
+				count: 2
 				id: "600EC8E8D06CF3BF"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1013,6 +1149,7 @@
 			]
 			id: "2C8CCBB849A085C1"
 			rewards: [{
+				count: 2
 				id: "6A9471CDC472D821"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1035,6 +1172,7 @@
 			]
 			id: "0947210E8A69DB84"
 			rewards: [{
+				count: 2
 				id: "4DC0953123CD6ABF"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1055,6 +1193,7 @@
 			]
 			id: "253E0D6D2F38DB28"
 			rewards: [{
+				count: 2
 				id: "6AACE77D0AB7F2D0"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1075,6 +1214,7 @@
 			]
 			id: "79325F05275A6041"
 			rewards: [{
+				count: 2
 				id: "015CB7441EE74682"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1103,11 +1243,6 @@
 				"Note: from here and above you will not get any more doge coins. Sorry!"
 			]
 			id: "571D6E7449ED876B"
-			rewards: [{
-				id: "3B3A9FAFF0431817"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
 			shape: "octagon"
 			size: 2.0d
 			subtitle: "Woah."
@@ -1123,6 +1258,7 @@
 			dependencies: ["687F155B59B5FC1C"]
 			id: "195B7677D3E2F874"
 			rewards: [{
+				count: 2
 				id: "4713A3FB5523118F"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1142,6 +1278,7 @@
 			]
 			id: "1F87E3C3B7E7B86F"
 			rewards: [{
+				count: 2
 				id: "0AF123F8F82FBA0A"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1158,6 +1295,7 @@
 			dependencies: ["1F87E3C3B7E7B86F"]
 			id: "10390BE89A74376A"
 			rewards: [{
+				count: 2
 				id: "055F71AD01DF4304"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1176,6 +1314,7 @@
 			dependencies: ["10390BE89A74376A"]
 			id: "77C63918DA40DB6D"
 			rewards: [{
+				count: 2
 				id: "1D514E8800692DF1"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1193,6 +1332,7 @@
 			dependencies: ["77C63918DA40DB6D"]
 			id: "0000EB23A4DB32DF"
 			rewards: [{
+				count: 2
 				id: "5BB0392A7AAB61E3"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1210,6 +1350,7 @@
 			dependencies: ["0000EB23A4DB32DF"]
 			id: "49CC37DA397CA3B3"
 			rewards: [{
+				count: 2
 				id: "3FB20264BF88B475"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1231,6 +1372,7 @@
 			]
 			id: "1F43AADC6C229EAF"
 			rewards: [{
+				count: 16
 				id: "4F931ABAB077CB30"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1250,6 +1392,7 @@
 			dependencies: ["2C8CCBB849A085C1"]
 			id: "5DBF28E106095546"
 			rewards: [{
+				count: 2
 				id: "32B6EDF0ECBAD83F"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1267,6 +1410,7 @@
 			dependencies: ["0608F68656DC2B06"]
 			id: "1E4509569E3F85B0"
 			rewards: [{
+				count: 2
 				id: "7D0BD986AEC82F49"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1288,6 +1432,7 @@
 			]
 			id: "7104D17C80C2DF74"
 			rewards: [{
+				count: 2
 				id: "2CC041B7E87E9262"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1322,6 +1467,7 @@
 			icon: "packagedavaritia:extreme_crafter"
 			id: "07978106CFD0D70C"
 			rewards: [{
+				count: 10
 				id: "0EB069B067195856"
 				item: "gtmutils:doge_coin"
 				type: "item"

--- a/.minecraft/config/ftbquests/quests/chapters/tier__ev.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier__ev.snbt
@@ -70,11 +70,32 @@
 				"7642FE788D211940"
 			]
 			id: "6307A99BEC83D5B8"
-			rewards: [{
-				id: "11F0049BD13C20C5"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					id: "11F0049BD13C20C5"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+				{
+					id: "7AD6E867A01DBA92"
+					item: {
+						Count: 1
+						id: "trophymanager:trophy"
+						tag: {
+							BaseBlock: "ae2:smooth_sky_stone_slab"
+							Name: "First Rocket"
+							OffsetY: 0.75d
+							Scale: 3
+							TrophyItem: {
+								Count: 1.0d
+								id: "ad_astra:tier_1_rocket"
+							}
+							TrophyType: "item"
+						}
+					}
+					type: "item"
+				}
+			]
 			shape: "none"
 			size: 3.0d
 			tasks: [{
@@ -99,11 +120,18 @@
 				}
 			}
 			id: "1A53D93C7BAAA472"
-			rewards: [{
-				id: "4FEDED61A50799E0"
-				item: "gtmutils:doge_coin"
-				type: "item"
-			}]
+			rewards: [
+				{
+					id: "0316DBF0ABF68D6B"
+					item: "ad_astra:white_flag"
+					type: "item"
+				}
+				{
+					id: "4FEDED61A50799E0"
+					item: "gtmutils:doge_coin"
+					type: "item"
+				}
+			]
 			tasks: [
 				{
 					id: "064FF7450B9DFB9E"
@@ -1231,6 +1259,7 @@
 			dependencies: ["228D20DB0820F303"]
 			id: "33DA634B88A5EEE2"
 			rewards: [{
+				count: 5
 				id: "0B4B510E1A05873C"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1255,6 +1284,7 @@
 			]
 			id: "56A354EB0D7C0ACE"
 			rewards: [{
+				count: 2
 				id: "61657DE5DAB9F8FA"
 				item: "gtmutils:doge_coin"
 				type: "item"
@@ -1691,6 +1721,7 @@
 		{
 			id: "69D2657F779DFFE6"
 			rewards: [{
+				count: 2
 				id: "27A5BD9DAD915539"
 				item: "gtmutils:doge_coin"
 				type: "item"


### PR DESCRIPTION
When SoG was updated to v1.4, the quests in the Tiers and Shop groups up through UHV had their rewards set to a single Doge Coin. This PR restores the rewards deleted in the conversion from gtceu:doge_coin to gtmutils:doge_coin.