### PR TITLE
Update quests

### DIFF
--- a/.minecraft/config/ftbquests/quests/chapters/tier_05__steam.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_05__steam.snbt
@@ -304,6 +304,7 @@
 			]
 			icon: "watersources:water_source_tier_1"
 			id: "0291490F6A1806BF"
+			optional: true
 			rewards: [{
 				id: "6CE24D37FB0901E8"
 				item: "gtmutils:doge_coin"
@@ -577,6 +578,7 @@
 				"You will need a lot of alloys, like red alloy for cables  and rubber dust, consider even making 2 of those."
 			]
 			id: "17956BCCD994D647"
+			optional: true
 			rewards: [{
 				id: "43545AC9B1F7EBCE"
 				item: "gtmutils:doge_coin"
@@ -598,6 +600,7 @@
 				"You will a lot of dusts so this is a must on my list."
 			]
 			id: "34505E178B1E2560"
+			optional: true
 			rewards: [{
 				id: "21D444370A2EE828"
 				item: "gtmutils:doge_coin"
@@ -635,6 +638,7 @@
 			dependencies: ["001955464B84E2C3"]
 			description: ["You can use liquid boilers with rock crushers and crucibles to get lava for a different way to make steam."]
 			id: "1904613EF69350E3"
+			optional: true
 			rewards: [{
 				id: "28DF44B636A883DF"
 				item: "gtmutils:doge_coin"
@@ -658,6 +662,7 @@
 				"Consider having both of them at the same time if u need materials like wood and flowers."
 			]
 			id: "6559C153909F6520"
+			optional: true
 			rewards: [{
 				id: "141C2FA7641205CF"
 				item: "gtmutils:doge_coin"
@@ -670,6 +675,19 @@
 			}]
 			x: 4.0d
 			y: 6.5d
+		}
+		{
+			dependencies: ["38CA5A0A1225A57C"]
+			id: "658FD2831D0EF031"
+			optional: true
+			subtitle: "The Steam Foundry is a multi-block alloy  smelter capable of 16 parallel recipes."
+			tasks: [{
+				id: "3E3B58AB409EAF08"
+				item: "steamadditions:steam_foundry"
+				type: "item"
+			}]
+			x: -6.5d
+			y: 5.5d
 		}
 	]
 	title: "&#f7bc57Tier 0.5 - Steam"

--- a/.minecraft/config/ftbquests/quests/chapters/tier_10__uev.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_10__uev.snbt
@@ -57,21 +57,25 @@
 				{
 					id: "4C9B69BC7B4F2EE8"
 					item: "gtceu:uev_electric_pump"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "1C7B1E7F4791E2DF"
 					item: "gtceu:uev_conveyor_module"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "552CA65E7A1EB0AC"
 					item: "gtceu:uev_electric_piston"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "723DC7A6FD36C2E8"
 					item: "gtceu:uev_robot_arm"
+					optional_task: true
 					type: "item"
 				}
 			]

--- a/.minecraft/config/ftbquests/quests/chapters/tier_11__uiv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_11__uiv.snbt
@@ -188,21 +188,25 @@
 				{
 					id: "79ADF8645FCD53D8"
 					item: "gtceu:uiv_electric_pump"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "6A2F617706E0EBBD"
 					item: "gtceu:uiv_conveyor_module"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "6F095ED71AA08387"
 					item: "gtceu:uiv_electric_piston"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "2AD312F04666E7CC"
 					item: "gtceu:uiv_robot_arm"
+					optional_task: true
 					type: "item"
 				}
 			]

--- a/.minecraft/config/ftbquests/quests/chapters/tier_1__lv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_1__lv.snbt
@@ -153,21 +153,25 @@
 				{
 					id: "5E64F124B62DC25D"
 					item: "gtceu:lv_electric_pump"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "12C287765290C8AD"
 					item: "gtceu:lv_conveyor_module"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "63178F82EDF2464E"
 					item: "gtceu:lv_electric_piston"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "11D7677025B56638"
 					item: "gtceu:lv_robot_arm"
+					optional_task: true
 					type: "item"
 				}
 			]
@@ -219,6 +223,7 @@
 				item: "gtmutils:doge_coin"
 				type: "item"
 			}]
+			subtitle: "Collect some air! To get your first oxygen for Lapis, try electrolyzing some water."
 			tasks: [{
 				id: "52A5BCFCB3EE611A"
 				item: "gtceu:lv_gas_collector"
@@ -1026,11 +1031,16 @@
 					type: "item"
 				}
 			]
-			x: -3.0d
+			title: "Squid Data Model"
+			x: -4.5d
 			y: 1.5d
 		}
 		{
-			dependencies: ["66079F4565A6B631"]
+			dependencies: [
+				"4F38FDE69E161339"
+				"2417824221561352"
+			]
+			dependency_requirement: "one_completed"
 			id: "696039828152042F"
 			rewards: [{
 				id: "6A43749BF2A97A44"
@@ -1436,7 +1446,7 @@
 				}
 			]
 			title: "Spider Data Model"
-			x: -4.5d
+			x: -3.0d
 			y: 1.5d
 		}
 		{
@@ -1545,6 +1555,17 @@
 			}]
 			x: 11.5d
 			y: 6.5d
+		}
+		{
+			id: "2417824221561352"
+			subtitle: "You can also get ink sacs through the extractinator. You'll lose your bucket(s)!"
+			tasks: [{
+				id: "60EBBE4C90F5F74F"
+				title: "Extractinator Method"
+				type: "checkmark"
+			}]
+			x: -6.0d
+			y: 1.5d
 		}
 	]
 	subtitle: ["Low Voltage"]

--- a/.minecraft/config/ftbquests/quests/chapters/tier_2__mv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_2__mv.snbt
@@ -33,7 +33,6 @@
 		}
 		{
 			dependencies: ["7D6C30089B9F8938"]
-			icon: "gtceu:mv_electric_motor"
 			id: "089AB7F6D2A6E393"
 			rewards: [{
 				id: "5A1689FA73444C5F"
@@ -49,21 +48,25 @@
 				{
 					id: "5A844197E86D2F49"
 					item: "gtceu:mv_electric_pump"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "791833A980E4E5F6"
 					item: "gtceu:mv_conveyor_module"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "51AEB98944ADB9D8"
 					item: "gtceu:mv_electric_piston"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "6D604F1B92DED539"
 					item: "gtceu:mv_robot_arm"
+					optional_task: true
 					type: "item"
 				}
 			]
@@ -367,8 +370,14 @@
 				type: "item"
 			}]
 			tasks: [{
-				id: "23970349ED58E513"
-				item: "gtceu:mv_distillery"
+				id: "7A267E751F8DE471"
+				item: {
+					Count: 1
+					id: "ftbfiltersystem:smart_filter"
+					tag: {
+						"ftbfiltersystem:filter": "or(item(gtceu:lv_distillery)item(gtceu:mv_distillery))"
+					}
+				}
 				type: "item"
 			}]
 			title: "Faster Cutter"
@@ -534,11 +543,17 @@
 				type: "item"
 			}]
 			tasks: [{
-				id: "676CC64871355A29"
-				item: "gtceu:mv_rock_crusher"
+				id: "676F5B9E88B24ED4"
+				item: {
+					Count: 1
+					id: "ftbfiltersystem:smart_filter"
+					tag: {
+						"ftbfiltersystem:filter": "or(item(gtceu:lv_rock_crusher)item(gtceu:mv_rock_crusher))"
+					}
+				}
 				type: "item"
 			}]
-			title: "Passiving everything!"
+			title: "Everything passified!"
 			x: -4.0d
 			y: -0.5d
 		}

--- a/.minecraft/config/ftbquests/quests/chapters/tier_3__hv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_3__hv.snbt
@@ -41,7 +41,6 @@
 		}
 		{
 			dependencies: ["3388F162BE5A4280"]
-			icon: "gtceu:hv_electric_motor"
 			id: "2F889EB9AB0A817D"
 			rewards: [{
 				id: "7CE6D7B15E11A9BF"
@@ -57,21 +56,25 @@
 				{
 					id: "462E324B7309A64B"
 					item: "gtceu:hv_electric_pump"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "2DF3CC63B11364F9"
 					item: "gtceu:hv_electric_piston"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "5C3B07A13D56FBBD"
 					item: "gtceu:hv_robot_arm"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "7F82EFBB216B7BF3"
 					item: "gtceu:hv_conveyor_module"
+					optional_task: true
 					type: "item"
 				}
 			]

--- a/.minecraft/config/ftbquests/quests/chapters/tier_5__iv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_5__iv.snbt
@@ -34,7 +34,6 @@
 		{
 			dependencies: ["5999DFCEB9FF4F3A"]
 			description: ["Have you gotten one of the more advanced rubbers yet?"]
-			icon: "gtceu:iv_electric_motor"
 			id: "700D75AB04659866"
 			rewards: [{
 				id: "085421951E7EF291"
@@ -50,21 +49,25 @@
 				{
 					id: "4E403D6736AC1353"
 					item: "gtceu:iv_electric_pump"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "2FFA400D3BAA7593"
 					item: "gtceu:iv_conveyor_module"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "5D4380AA1717A30C"
 					item: "gtceu:iv_robot_arm"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "212D12AAF0B0C474"
 					item: "gtceu:iv_electric_piston"
+					optional_task: true
 					type: "item"
 				}
 			]

--- a/.minecraft/config/ftbquests/quests/chapters/tier_6__luv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_6__luv.snbt
@@ -694,7 +694,6 @@
 				"2308A0C52AFD7A2B"
 				"2F2D9E00D5C5C71A"
 			]
-			icon: "gtceu:luv_electric_motor"
 			id: "3172CE3676E125EA"
 			rewards: [{
 				id: "20534626574E296A"
@@ -710,21 +709,25 @@
 				{
 					id: "5EA69BB06A4B97ED"
 					item: "gtceu:luv_electric_pump"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "42C3EC7519E592AA"
 					item: "gtceu:luv_conveyor_module"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "74711C660EE06891"
 					item: "gtceu:luv_electric_piston"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "5B68E6D0EA004927"
 					item: "gtceu:luv_robot_arm"
+					optional_task: true
 					type: "item"
 				}
 			]

--- a/.minecraft/config/ftbquests/quests/chapters/tier_7__zpm.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_7__zpm.snbt
@@ -116,7 +116,6 @@
 		}
 		{
 			dependencies: ["7E9A45F1598B0197"]
-			icon: "gtceu:zpm_conveyor_module"
 			id: "146B5BFAD44A9A2A"
 			rewards: [{
 				id: "265816DCC825F896"
@@ -127,6 +126,7 @@
 				{
 					id: "4CC2AEEEC471EC61"
 					item: "gtceu:zpm_conveyor_module"
+					optional_task: true
 					type: "item"
 				}
 				{
@@ -137,16 +137,19 @@
 				{
 					id: "394C15520F93B203"
 					item: "gtceu:zpm_electric_piston"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "2DED68607D4342B3"
 					item: "gtceu:zpm_electric_pump"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "39F98AD4DBD3F070"
 					item: "gtceu:zpm_robot_arm"
+					optional_task: true
 					type: "item"
 				}
 			]

--- a/.minecraft/config/ftbquests/quests/chapters/tier_8__uv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_8__uv.snbt
@@ -41,7 +41,6 @@
 		}
 		{
 			dependencies: ["164F9100DAB09566"]
-			icon: "gtceu:uv_electric_motor"
 			id: "37F84238ECE73317"
 			rewards: [{
 				id: "530FCEAFC2D4D1A8"
@@ -57,21 +56,25 @@
 				{
 					id: "4384D174551311CF"
 					item: "gtceu:uv_electric_pump"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "19B8B861EA67B9DF"
 					item: "gtceu:uv_conveyor_module"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "6EFBD438114F52E2"
 					item: "gtceu:uv_robot_arm"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "58B8006624DC9615"
 					item: "gtceu:uv_electric_piston"
+					optional_task: true
 					type: "item"
 				}
 			]

--- a/.minecraft/config/ftbquests/quests/chapters/tier_9__uhv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_9__uhv.snbt
@@ -666,21 +666,25 @@
 				{
 					id: "65FE6E9075D72AED"
 					item: "gtceu:uhv_electric_pump"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "4DB129468B61860B"
-					item: { Count: 64, id: "gtceu:uhv_conveyor_module" }
+					item: "gtceu:uhv_conveyor_module"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "03E48C972C035003"
 					item: "gtceu:uhv_electric_piston"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "6EDB345805BB74B7"
 					item: "gtceu:uhv_robot_arm"
+					optional_task: true
 					type: "item"
 				}
 			]

--- a/.minecraft/config/ftbquests/quests/chapters/tier__ev.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier__ev.snbt
@@ -391,7 +391,6 @@
 		}
 		{
 			dependencies: ["6840081D7D2DCBEE"]
-			icon: "gtceu:ev_electric_motor"
 			id: "50B880443FF71E21"
 			rewards: [{
 				id: "346C31218AC80A8C"
@@ -407,21 +406,25 @@
 				{
 					id: "2C42637FA0C91F7E"
 					item: "gtceu:ev_electric_pump"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "2F03C497A4404960"
 					item: "gtceu:ev_conveyor_module"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "22DB81CB3CFA2047"
 					item: "gtceu:ev_electric_piston"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "17ED483117E5D87D"
 					item: "gtceu:ev_robot_arm"
+					optional_task: true
 					type: "item"
 				}
 			]


### PR DESCRIPTION
Made pumps, conveyors, robot arms and pistons optional (to not gate progression of machines that don't need them).

Added checkbox quest as pre-requisite for ink sacs, since they can be obtained through the extractinator (as to not gate mixer behind HNN).

Added Steam foundry quest as optional quest in the steam tab (as it can easily be made there) Made some quests optional in Steam.

In MV, made a filter for Distillery and Rock Crusher quests to allow for both basic and advanced to be used.