### PR TITLE
Changing/Adding Recipe(s)

### DIFF
--- a/.minecraft/kubejs/server_scripts/multiblocks.js
+++ b/.minecraft/kubejs/server_scripts/multiblocks.js
@@ -238,6 +238,12 @@ event.recipes.gtceu.rock_crusher('deepslate')
     .duration(16)
     .EUt(GTValues.VA[GTValues.EV]);
 
+event.recipes.gtceu.rock_crusher('netherrackbreaker')
+    .notConsumable('minecraft:netherrack')
+    .itemOutputs('minecraft:netherrack')
+    .duration(16)
+    .EUt(GTValues.VA[GTValues.EV]);
+
 event.shaped(
     'gtceu:tectonic_plate_accelerator',
     ['GRG', 'ACA', 'PBD'],

--- a/.minecraft/kubejs/server_scripts/multiblocks.js
+++ b/.minecraft/kubejs/server_scripts/multiblocks.js
@@ -232,6 +232,12 @@ event.recipes.gtceu.rock_crusher('marble')
     .duration(16)
     .EUt(GTValues.VA[GTValues.HV]);
 
+event.recipes.gtceu.rock_crusher('deepslate')
+    .notConsumable('minecraft:deepslate')
+    .itemOutputs('minecraft:deepslate')
+    .duration(16)
+    .EUt(GTValues.VA[GTValues.EV]);
+
 event.shaped(
     'gtceu:tectonic_plate_accelerator',
     ['GRG', 'ACA', 'PBD'],

--- a/.minecraft/kubejs/server_scripts/power/tesla_tower.js
+++ b/.minecraft/kubejs/server_scripts/power/tesla_tower.js
@@ -11,7 +11,7 @@ ServerEvents.recipes(sog => {
     .EUt(-(GTValues.V[GTValues.UV]))
     sog.recipes.gtceu.tesla_tower('tesla_mk2')
     .chancedInput('kubejs:tesla_coil_mk2', 500, 0)
-    .chancedOutput('gtceu:small_teslarium_dust', 1000, 0)
+    .chancedOutput('gtceu:small_teslarium_dust', 2500, 0)
     .duration(200)
     .EUt(-(GTValues.V[GTValues.UEV]))
     sog.recipes.gtceu.tesla_tower('tesla_mk3')


### PR DESCRIPTION
Tesla MK2 buff
   - People mostly using solars, it's not a huuge buff for teslas but a reasonable one for sure - after that you will need 3.2 mk2 teslas to run one mk3 instead of 8 so a bit more than a x2 buff basically
   - Deepslate recipe for Tectonic Plate Multiblock
   - Added Netherrack to Tectonic Plate Multiblock as well for QSP recipe