### PR TITLE
Quest changes

### DIFF
--- a/.minecraft/config/ftbquests/quests/chapters/rich.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/rich.snbt
@@ -17,17 +17,6 @@
 	quest_links: [ ]
 	quests: [
 		{
-			dependencies: ["792CA960CA776F9B"]
-			id: "4119D33BDAF6DC1F"
-			tasks: [{
-				id: "7BFC919F16E043C9"
-				item: "gtmutils:copper_credit"
-				type: "item"
-			}]
-			x: 0.0d
-			y: 0.0d
-		}
-		{
 			description: [
 				"This is rich part of the shop."
 				""
@@ -46,7 +35,6 @@
 			y: 0.0d
 		}
 		{
-			dependencies: ["4119D33BDAF6DC1F"]
 			id: "1CA316B993A3A462"
 			tasks: [{
 				id: "1BD6CF65E983DACA"

--- a/.minecraft/config/ftbquests/quests/chapters/tier_05__steam.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_05__steam.snbt
@@ -671,6 +671,19 @@
 			x: 4.0d
 			y: 6.5d
 		}
+		{
+			dependencies: ["38CA5A0A1225A57C"]
+			description: ["The Steam Foundry is a multiblock alloy smelter capable of 16 parallel recipes."]
+			id: "106D098AC5C2A887"
+			subtitle: "The Steam Foundry is a multi-block alloy  smelter capable of 16 parallel recipes."
+			tasks: [{
+				id: "61C30DF65427809E"
+				item: "steamadditions:steam_foundry"
+				type: "item"
+			}]
+			x: -4.0d
+			y: 5.0d
+		}
 	]
 	title: "&#f7bc57Tier 0.5 - Steam"
 }

--- a/.minecraft/config/ftbquests/quests/chapters/tier_10__uev.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_10__uev.snbt
@@ -5,7 +5,7 @@
 	group: "6B3EFCC5BFD49997"
 	icon: "draconicevolution:draconium_ingot"
 	id: "6390E93A0F02A823"
-	order_index: 12
+	order_index: 13
 	quest_links: [
 		{
 			id: "35C91498B369EDD3"
@@ -48,33 +48,38 @@
 			description: ["Unlike &cUHV&r tier, here you dont need a crazy line to get components. Don't worry."]
 			hide_details_until_startable: false
 			id: "071D143BE842866F"
-			tasks: [
-				{
-					id: "45983AC9ADF06A3D"
-					item: "gtceu:uev_electric_motor"
-					type: "item"
+			tasks: [{
+				id: "1F8A51BCE716307A"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:uev_electric_motor"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uev_electric_pump"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uev_conveyor_module"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uev_electric_piston"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uev_robot_arm"
+							}
+						]
+					}
 				}
-				{
-					id: "4C9B69BC7B4F2EE8"
-					item: "gtceu:uev_electric_pump"
-					type: "item"
-				}
-				{
-					id: "1C7B1E7F4791E2DF"
-					item: "gtceu:uev_conveyor_module"
-					type: "item"
-				}
-				{
-					id: "552CA65E7A1EB0AC"
-					item: "gtceu:uev_electric_piston"
-					type: "item"
-				}
-				{
-					id: "723DC7A6FD36C2E8"
-					item: "gtceu:uev_robot_arm"
-					type: "item"
-				}
-			]
+				type: "item"
+			}]
 			title: "UEV Parts #1"
 			x: 10.0d
 			y: 3.0d
@@ -87,18 +92,26 @@
 			]
 			description: ["This took long enough, right?"]
 			id: "38B15640E2E9E90E"
-			tasks: [
-				{
-					id: "7E6B245325184EF3"
-					item: "gtceu:uev_emitter"
-					type: "item"
+			tasks: [{
+				id: "24912D240EE355F2"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:uev_sensor"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uev_emitter"
+							}
+						]
+					}
 				}
-				{
-					id: "582C6447B29B0C68"
-					item: "gtceu:uev_sensor"
-					type: "item"
-				}
-			]
+				type: "item"
+			}]
 			title: "UEV parts  #2"
 			x: 8.5d
 			y: 4.5d

--- a/.minecraft/config/ftbquests/quests/chapters/tier_11__uiv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_11__uiv.snbt
@@ -179,33 +179,38 @@
 		{
 			dependencies: ["093B75408D3BEC38"]
 			id: "176C5C21B6EDF8FA"
-			tasks: [
-				{
-					id: "55F7F5A1F0413FC1"
-					item: "gtceu:uiv_electric_motor"
-					type: "item"
+			tasks: [{
+				id: "306BB4D98E0E39E0"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:uiv_electric_motor"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uiv_electric_pump"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uiv_conveyor_module"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uiv_electric_piston"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uiv_robot_arm"
+							}
+						]
+					}
 				}
-				{
-					id: "79ADF8645FCD53D8"
-					item: "gtceu:uiv_electric_pump"
-					type: "item"
-				}
-				{
-					id: "6A2F617706E0EBBD"
-					item: "gtceu:uiv_conveyor_module"
-					type: "item"
-				}
-				{
-					id: "6F095ED71AA08387"
-					item: "gtceu:uiv_electric_piston"
-					type: "item"
-				}
-				{
-					id: "2AD312F04666E7CC"
-					item: "gtceu:uiv_robot_arm"
-					type: "item"
-				}
-			]
+				type: "item"
+			}]
 			title: "UIV Components"
 			x: 11.0d
 			y: 4.5d
@@ -271,23 +276,30 @@
 		{
 			dependencies: ["5909F49C7467BCDF"]
 			id: "1EF5F78DFEF2DA1F"
-			tasks: [
-				{
-					id: "5A6EBCBE14E5D689"
-					item: "gtceu:uiv_field_generator"
-					type: "item"
+			tasks: [{
+				id: "719C9987B89A9582"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:uiv_sensor"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uiv_emitter"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uiv_field_generator"
+							}
+						]
+					}
 				}
-				{
-					id: "4E0E3007D2EB392F"
-					item: "gtceu:uiv_emitter"
-					type: "item"
-				}
-				{
-					id: "0AB571612ACC1AC7"
-					item: "gtceu:uiv_sensor"
-					type: "item"
-				}
-			]
+				type: "item"
+			}]
 			title: "UIV Components #2"
 			x: 2.5d
 			y: 8.5d

--- a/.minecraft/config/ftbquests/quests/chapters/tier_14__max.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_14__max.snbt
@@ -543,6 +543,76 @@
 			x: 13.0d
 			y: 0.0d
 		}
+		{
+			dependencies: ["4ECF59E2AA84D7CB"]
+			id: "332FB95A5CB2FF14"
+			tasks: [{
+				id: "579666EDF61C6726"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:uxv_electric_motor"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uxv_electric_pump"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uxv_conveyor_module"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uxv_electric_piston"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uxv_robot_arm"
+							}
+						]
+					}
+				}
+				type: "item"
+			}]
+			title: "UXV Components"
+			x: 7.5d
+			y: -2.0d
+		}
+		{
+			dependencies: ["4ECF59E2AA84D7CB"]
+			id: "242D6D4BC9113A7E"
+			tasks: [{
+				id: "110A68EAC5725762"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:uxv_sensor"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uxv_emitter"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uxv_field_generator"
+							}
+						]
+					}
+				}
+				type: "item"
+			}]
+			title: "UXV Components #2"
+			x: 8.5d
+			y: -2.0d
+		}
 	]
 	subtitle: ["Ultra Extreme Voltage"]
 	title: "&#FFFFFF&lT&#EDEDED&li&#DBDBDB&le&#C9C9C9&lr &#A4A4A4&l1&#929292&l2 &#6E6E6E&l- &#494949&lU&#373737&lX&#252525&lV"

--- a/.minecraft/config/ftbquests/quests/chapters/tier_1__lv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_1__lv.snbt
@@ -144,33 +144,38 @@
 				type: "item"
 			}]
 			subtitle: "GT:NH reference :o"
-			tasks: [
-				{
-					id: "36E1A5850CCDF01D"
-					item: "gtceu:lv_electric_motor"
-					type: "item"
+			tasks: [{
+				id: "64C10B01738A098C"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:lv_electric_motor"
+							}
+							{
+								Count: 1b
+								id: "gtceu:lv_conveyor_module"
+							}
+							{
+								Count: 1b
+								id: "gtceu:lv_electric_pump"
+							}
+							{
+								Count: 1b
+								id: "gtceu:lv_electric_piston"
+							}
+							{
+								Count: 1b
+								id: "gtceu:lv_robot_arm"
+							}
+						]
+					}
 				}
-				{
-					id: "5E64F124B62DC25D"
-					item: "gtceu:lv_electric_pump"
-					type: "item"
-				}
-				{
-					id: "12C287765290C8AD"
-					item: "gtceu:lv_conveyor_module"
-					type: "item"
-				}
-				{
-					id: "63178F82EDF2464E"
-					item: "gtceu:lv_electric_piston"
-					type: "item"
-				}
-				{
-					id: "11D7677025B56638"
-					item: "gtceu:lv_robot_arm"
-					type: "item"
-				}
-			]
+				type: "item"
+			}]
 			title: "You will hate this on LV #1"
 			x: 0.0d
 			y: 8.0d
@@ -212,7 +217,7 @@
 		}
 		{
 			dependencies: ["600C9FE63DAFB132"]
-			description: ["Collect some air!"]
+			description: ["Collect some air! To get your first oxygen for Lapis, try electrolyzing some water."]
 			id: "204D8FAA756928C4"
 			rewards: [{
 				id: "4176296A5AF320C3"
@@ -401,18 +406,26 @@
 				item: "gtmutils:doge_coin"
 				type: "item"
 			}]
-			tasks: [
-				{
-					id: "7BBC8409AC5516F8"
-					item: "gtceu:lv_sensor"
-					type: "item"
+			tasks: [{
+				id: "177C6F3158A287ED"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:lv_sensor"
+							}
+							{
+								Count: 1b
+								id: "gtceu:lv_emitter"
+							}
+						]
+					}
 				}
-				{
-					id: "7850157F45000A05"
-					item: "gtceu:lv_emitter"
-					type: "item"
-				}
-			]
+				type: "item"
+			}]
 			title: "You will hate this on LV #2"
 			x: 6.5d
 			y: 8.0d
@@ -662,7 +675,6 @@
 			y: 5.0d
 		}
 		{
-			dependencies: ["780137604FB5DEC9"]
 			id: "7CCA83876C2A61BB"
 			rewards: [{
 				id: "3485084EB33F8204"
@@ -936,7 +948,11 @@
 			y: 8.0d
 		}
 		{
-			dependencies: ["62F9642692D0B556"]
+			dependencies: [
+				"4F38FDE69E161339"
+				"0718B686D7E82E27"
+			]
+			dependency_requirement: "one_completed"
 			description: [
 				"Yes, this is Hostile Neural Networks. Remember, this pack is peaceful, so the way you will get the data models is gonna be buying them with items in the quests."
 				""
@@ -967,11 +983,11 @@
 			]
 			title: "Hostile Neural Networks"
 			x: -3.0d
-			y: 3.0d
+			y: 1.5d
 		}
 		{
 			can_repeat: true
-			dependencies: ["66079F4565A6B631"]
+			dependencies: ["62F9642692D0B556"]
 			icon: {
 				Count: 1
 				id: "hostilenetworks:data_model"
@@ -1026,11 +1042,16 @@
 					type: "item"
 				}
 			]
-			x: -3.0d
-			y: 1.5d
+			title: "Squid Data Model"
+			x: -2.0d
+			y: 3.5d
 		}
 		{
-			dependencies: ["66079F4565A6B631"]
+			dependencies: [
+				"19B88F40FFC77FBE"
+				"66079F4565A6B631"
+			]
+			dependency_requirement: "one_completed"
 			id: "696039828152042F"
 			rewards: [{
 				id: "6A43749BF2A97A44"
@@ -1372,7 +1393,7 @@
 		}
 		{
 			can_repeat: true
-			dependencies: ["66079F4565A6B631"]
+			dependencies: ["62F9642692D0B556"]
 			icon: {
 				Count: 1
 				id: "hostilenetworks:data_model"
@@ -1436,8 +1457,8 @@
 				}
 			]
 			title: "Spider Data Model"
-			x: -4.5d
-			y: 1.5d
+			x: -3.0d
+			y: 3.5d
 		}
 		{
 			dependencies: ["7CCA83876C2A61BB"]
@@ -1545,6 +1566,17 @@
 			}]
 			x: 11.5d
 			y: 6.5d
+		}
+		{
+			id: "19B88F40FFC77FBE"
+			subtitle: "You can also get ink sacs through the extractinator. You'll lose your bucket(s)!"
+			tasks: [{
+				id: "3782AD7E23F31ED9"
+				title: "Extractinator Method"
+				type: "checkmark"
+			}]
+			x: -4.5d
+			y: 1.5d
 		}
 	]
 	subtitle: ["Low Voltage"]

--- a/.minecraft/config/ftbquests/quests/chapters/tier_2__mv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_2__mv.snbt
@@ -49,21 +49,25 @@
 				{
 					id: "5A844197E86D2F49"
 					item: "gtceu:mv_electric_pump"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "791833A980E4E5F6"
 					item: "gtceu:mv_conveyor_module"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "51AEB98944ADB9D8"
 					item: "gtceu:mv_electric_piston"
+					optional_task: true
 					type: "item"
 				}
 				{
 					id: "6D604F1B92DED539"
 					item: "gtceu:mv_robot_arm"
+					optional_task: true
 					type: "item"
 				}
 			]
@@ -161,6 +165,7 @@
 				{
 					id: "384EF387955DC15A"
 					item: "gtceu:mv_sensor"
+					optional_task: true
 					type: "item"
 				}
 			]
@@ -367,8 +372,23 @@
 				type: "item"
 			}]
 			tasks: [{
-				id: "23970349ED58E513"
-				item: "gtceu:mv_distillery"
+				id: "62C63E75EAC2CC4A"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:lv_distillery"
+							}
+							{
+								Count: 1b
+								id: "gtceu:mv_distillery"
+							}
+						]
+					}
+				}
 				type: "item"
 			}]
 			title: "Faster Cutter"
@@ -525,7 +545,6 @@
 			y: 2.5d
 		}
 		{
-			dependencies: ["089AB7F6D2A6E393"]
 			description: ["This is the start of infinite clay, aluminium, lithium, etc."]
 			id: "070CEF22C846C7D6"
 			rewards: [{
@@ -534,11 +553,34 @@
 				type: "item"
 			}]
 			tasks: [{
-				id: "676CC64871355A29"
-				item: "gtceu:mv_rock_crusher"
+				id: "4024CFB37EAC86D4"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:lp_steam_rock_crusher"
+							}
+							{
+								Count: 1b
+								id: "gtceu:hp_steam_rock_crusher"
+							}
+							{
+								Count: 1b
+								id: "gtceu:lv_rock_crusher"
+							}
+							{
+								Count: 1b
+								id: "gtceu:mv_rock_crusher"
+							}
+						]
+					}
+				}
 				type: "item"
 			}]
-			title: "Passiving everything!"
+			title: "Passive everything!"
 			x: -4.0d
 			y: -0.5d
 		}
@@ -708,7 +750,11 @@
 			y: 8.0d
 		}
 		{
-			dependencies: ["62F0AC69281C7C29"]
+			dependencies: [
+				"62F0AC69281C7C29"
+				"7652DBA6D0CC8406"
+			]
+			dependency_requirement: "one_completed"
 			description: ["Silicon Boules, those are kinda annoying to craft early game. You could consider passiving them, but remember that the will get replaced later by other boules like the phosphorus ones."]
 			id: "2CEF142F1347E4B7"
 			rewards: [{
@@ -1121,7 +1167,7 @@
 				item: "gtceu:polyethylene_bucket"
 				type: "item"
 			}]
-			title: "&bPolyethelene"
+			title: "&bPolyethylene"
 			x: 10.0d
 			y: 13.0d
 		}
@@ -1347,7 +1393,7 @@
 				item: "gtceu:hsc_superconductor_single_wire"
 				type: "item"
 			}]
-			x: 3.0d
+			x: 1.0d
 			y: 7.0d
 		}
 		{
@@ -1371,6 +1417,21 @@
 			title: "Ouch!"
 			x: 11.5d
 			y: 6.0d
+		}
+		{
+			description: [
+				"You can use the stone/clay line to get silicon but there are other ways too!"
+				""
+				"So now you can use the stone/clay line or find another way - your decision"
+			]
+			id: "7652DBA6D0CC8406"
+			tasks: [{
+				id: "22461F9B25CA4436"
+				title: "Silicon needs"
+				type: "checkmark"
+			}]
+			x: 3.0d
+			y: 7.0d
 		}
 	]
 	subtitle: ["Medium Voltage"]

--- a/.minecraft/config/ftbquests/quests/chapters/tier_3__hv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_3__hv.snbt
@@ -19,7 +19,7 @@
 			id: "25E4C75523025300"
 			linked_quest: "26C62836B41D0095"
 			x: -7.5d
-			y: 17.0d
+			y: 17.5d
 		}
 	]
 	quests: [
@@ -48,33 +48,38 @@
 				item: "gtmutils:doge_coin"
 				type: "item"
 			}]
-			tasks: [
-				{
-					id: "423EDF8F2AB7E967"
-					item: "gtceu:hv_electric_motor"
-					type: "item"
+			tasks: [{
+				id: "1DB5D28132FDA74C"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:hv_electric_motor"
+							}
+							{
+								Count: 1b
+								id: "gtceu:hv_electric_pump"
+							}
+							{
+								Count: 1b
+								id: "gtceu:hv_electric_piston"
+							}
+							{
+								Count: 1b
+								id: "gtceu:hv_conveyor_module"
+							}
+							{
+								Count: 1b
+								id: "gtceu:hv_robot_arm"
+							}
+						]
+					}
 				}
-				{
-					id: "462E324B7309A64B"
-					item: "gtceu:hv_electric_pump"
-					type: "item"
-				}
-				{
-					id: "2DF3CC63B11364F9"
-					item: "gtceu:hv_electric_piston"
-					type: "item"
-				}
-				{
-					id: "5C3B07A13D56FBBD"
-					item: "gtceu:hv_robot_arm"
-					type: "item"
-				}
-				{
-					id: "7F82EFBB216B7BF3"
-					item: "gtceu:hv_conveyor_module"
-					type: "item"
-				}
-			]
+				type: "item"
+			}]
 			title: "You will hate this on HV #1"
 			x: 0.0d
 			y: 3.5d
@@ -264,7 +269,6 @@
 			y: 8.5d
 		}
 		{
-			dependencies: ["4E2A91E8BAAE3B4F"]
 			id: "52B4917D6B7C521B"
 			rewards: [{
 				id: "3DC891822EC6BBF9"
@@ -301,34 +305,44 @@
 				"2F889EB9AB0A817D"
 				"3C9A91B8BD07C033"
 			]
+			description: ["These new HV machines could be helpful for your journey!"]
 			id: "259C1DD19C9D3DBA"
 			rewards: [{
 				id: "0D7D564A6B630631"
 				item: "gtmutils:doge_coin"
 				type: "item"
 			}]
-			tasks: [
-				{
-					id: "570686EFF8AA24B1"
-					item: "gtceu:hv_cutter"
-					type: "item"
+			tasks: [{
+				id: "1CCD6779F28322D1"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:hv_cutter"
+							}
+							{
+								Count: 1b
+								id: "gtceu:hv_laser_engraver"
+							}
+						]
+					}
 				}
-				{
-					id: "50BB1C24ABCBB4B1"
-					item: "gtceu:hv_laser_engraver"
-					type: "item"
-				}
-			]
+				type: "item"
+			}]
 			title: "&6New Infrastructure"
 			x: 4.0d
-			y: 3.5d
+			y: 5.5d
 		}
 		{
-			dependencies: [
-				"2F889EB9AB0A817D"
-				"6A6162225FADF88B"
+			dependencies: ["2F889EB9AB0A817D"]
+			description: [
+				"The cleanroom is a multiblock that can be different sizes, ranging from 5x5x5 to 15x15x15. You will need a diode to make energy enter the room safely while maintaining the multiblock clean."
+				""
+				"Pro tip: You can eventually use some energy producers in it (solar in cleanroom is goated)!"
 			]
-			description: ["The cleanroom is a multiblock that can be different sizes, ranging from 5x5x5 to 15x15x15. You will need a diode to make energy enter the room safely while maintaining the multiblock clean."]
 			hide_text_until_complete: false
 			icon: "gtceu:cleanroom"
 			id: "63367A2F12D66CC4"
@@ -351,8 +365,34 @@
 					type: "item"
 				}
 				{
-					id: "56EBD093E2DE658A"
-					item: "gtceu:hv_diode"
+					count: 8L
+					id: "44A32835E57E480B"
+					item: { Count: 8, id: "gtceu:filter_casing" }
+					type: "item"
+				}
+				{
+					id: "3CC8C6A3FD5C198E"
+					item: {
+						Count: 1
+						id: "itemfilters:or"
+						tag: {
+							items: [
+								{
+									Count: 1b
+									id: "gtceu:lv_diode"
+								}
+								{
+									Count: 1b
+									id: "gtceu:mv_diode"
+								}
+								{
+									Count: 1b
+									id: "gtceu:hv_diode"
+								}
+							]
+						}
+					}
+					optional_task: true
 					type: "item"
 				}
 			]
@@ -362,9 +402,9 @@
 		}
 		{
 			dependencies: [
-				"078B3FD004417E2B"
 				"7B3FC49BA4E485BC"
 				"3FAB7F4CE25AA8AA"
+				"19C717F4D50C5D76"
 			]
 			dependency_requirement: "one_completed"
 			description: [
@@ -437,9 +477,10 @@
 					type: "item"
 				}
 				{
+					consume_items: true
 					count: 4L
 					id: "7CF50EE1C5D46023"
-					item: { Count: 4, id: "gtceu:red_steel_gear" }
+					item: "gtceu:red_steel_gear"
 					type: "item"
 				}
 			]
@@ -622,8 +663,8 @@
 				type: "item"
 			}]
 			tasks: [{
-				id: "35E20FFF4864C873"
-				item: "gtceu:hv_centrifuge"
+				id: "21F37368EBB906A9"
+				item: "gtceu:hv_electrolyzer"
 				type: "item"
 			}]
 			x: 0.0d
@@ -677,7 +718,7 @@
 				type: "item"
 			}]
 			x: 4.0d
-			y: 17.0d
+			y: 17.5d
 		}
 		{
 			dependencies: [
@@ -784,10 +825,6 @@
 			y: 14.5d
 		}
 		{
-			dependencies: [
-				"63367A2F12D66CC4"
-				"259C1DD19C9D3DBA"
-			]
 			description: ["Remember that orange lens we gave you?"]
 			id: "75AF3E9D764EFFBB"
 			rewards: [{
@@ -804,7 +841,10 @@
 			y: 3.5d
 		}
 		{
-			dependencies: ["75AF3E9D764EFFBB"]
+			dependencies: [
+				"75AF3E9D764EFFBB"
+				"63367A2F12D66CC4"
+			]
 			id: "065E72A43E5B9F63"
 			rewards: [{
 				id: "79DDFCD2349960E1"
@@ -899,10 +939,13 @@
 		{
 			dependencies: [
 				"146DAC8F4E639BE1"
+				"51811E951FAEAC8F"
 				"26C62836B41D0095"
+				"01F2A074F26982C1"
 			]
 			description: ["Polyethylene + copper + sulfuric acid"]
 			id: "2DE4387D5B19D55A"
+			min_required_dependencies: 2
 			rewards: [{
 				id: "27BFF40441B137E7"
 				item: "gtmutils:doge_coin"
@@ -1429,7 +1472,7 @@
 				type: "item"
 			}]
 			x: 5.5d
-			y: 3.5d
+			y: 5.0d
 		}
 		{
 			description: ["Please choose iron(III) chloride."]
@@ -1462,6 +1505,66 @@
 			title: "Dip the board in!"
 			x: -8.5d
 			y: 11.0d
+		}
+		{
+			description: ["You can use the ender air recipe, the endstone one or nickel processing - if you choose nickel processing just check this quest and unlock the platinum ingot quest!"]
+			id: "19C717F4D50C5D76"
+			tasks: [{
+				id: "3AED7451F79C74C9"
+				title: "Nickel Processing"
+				type: "checkmark"
+			}]
+			x: -2.5d
+			y: 6.0d
+		}
+		{
+			dependencies: ["2F889EB9AB0A817D"]
+			description: ["With this guy you'll never need to worry about maintenance anymore!"]
+			id: "67DD51D78756786E"
+			rewards: [{
+				id: "201509F2B41021DB"
+				item: "gtmutils:doge_coin"
+				type: "item"
+			}]
+			tasks: [{
+				id: "3915B12EA85D714B"
+				item: "gtceu:auto_maintenance_hatch"
+				type: "item"
+			}]
+			x: 1.0d
+			y: 4.5d
+		}
+		{
+			description: [
+				"You can eventually use the Sulfuric Acid skip in the LCR as well so it's your choice to choose!"
+				""
+				"If you check this and the poly checkmark Quest then you'll unlock the Circuit Board Quest aswell!"
+			]
+			id: "51811E951FAEAC8F"
+			tasks: [{
+				id: "18A683C30E7A64F1"
+				title: "The LCR-Way"
+				type: "checkmark"
+			}]
+			x: -6.5d
+			y: 16.5d
+		}
+		{
+			description: [
+				"You don't have to use Polyethylene, you know?"
+				"PVC or PTFE are other options as well - eventually later PBI."
+				""
+				"If you check this and the Sulfuric Acid checkmark Quest then you'll unlock the Circuit Board Quest aswell!"
+			]
+			id: "01F2A074F26982C1"
+			tasks: [{
+				id: "7EA3E3C1BC8359D0"
+				title: "Other polys"
+				type: "checkmark"
+			}]
+			title: "Other Polys"
+			x: -8.5d
+			y: 16.5d
 		}
 	]
 	subtitle: ["High Voltage"]

--- a/.minecraft/config/ftbquests/quests/chapters/tier_5__iv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_5__iv.snbt
@@ -41,33 +41,38 @@
 				item: "gtmutils:doge_coin"
 				type: "item"
 			}]
-			tasks: [
-				{
-					id: "6FDEA489E3F4D806"
-					item: "gtceu:iv_electric_motor"
-					type: "item"
+			tasks: [{
+				id: "269588B81233C5BA"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:iv_electric_motor"
+							}
+							{
+								Count: 1b
+								id: "gtceu:iv_electric_pump"
+							}
+							{
+								Count: 1b
+								id: "gtceu:iv_conveyor_module"
+							}
+							{
+								Count: 1b
+								id: "gtceu:iv_electric_piston"
+							}
+							{
+								Count: 1b
+								id: "gtceu:iv_robot_arm"
+							}
+						]
+					}
 				}
-				{
-					id: "4E403D6736AC1353"
-					item: "gtceu:iv_electric_pump"
-					type: "item"
-				}
-				{
-					id: "2FFA400D3BAA7593"
-					item: "gtceu:iv_conveyor_module"
-					type: "item"
-				}
-				{
-					id: "5D4380AA1717A30C"
-					item: "gtceu:iv_robot_arm"
-					type: "item"
-				}
-				{
-					id: "212D12AAF0B0C474"
-					item: "gtceu:iv_electric_piston"
-					type: "item"
-				}
-			]
+				type: "item"
+			}]
 			title: "Do you?"
 			x: 0.0d
 			y: 6.0d
@@ -1203,6 +1208,7 @@
 				"165BA28A8FBA4556"
 			]
 			id: "5080DC298EE66D18"
+			min_required_dependencies: 2
 			rewards: [{
 				id: "44FFDBA9E1452C1E"
 				item: "gtmutils:doge_coin"
@@ -1388,6 +1394,7 @@
 				"23F1153372A0B7D6"
 				"15A09F14F12AE9B2"
 				"6071D79FFF8DCE13"
+				"711FD6000148A2CE"
 			]
 			description: [
 				"First big multiblock machine."
@@ -1401,6 +1408,7 @@
 				"This one *can't* parallelize though, unlike the EBF later on."
 			]
 			id: "7243EE3F57F3A31A"
+			min_required_dependencies: 3
 			rewards: [{
 				id: "567A85200C4DCE01"
 				item: "gtmutils:doge_coin"
@@ -1573,18 +1581,26 @@
 				item: "gtmutils:doge_coin"
 				type: "item"
 			}]
-			tasks: [
-				{
-					id: "5412A6DF4DDA5656"
-					item: "gtceu:iv_emitter"
-					type: "item"
+			tasks: [{
+				id: "4FC7DB665AAA4BB4"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:iv_emitter"
+							}
+							{
+								Count: 1b
+								id: "gtceu:iv_sensor"
+							}
+						]
+					}
 				}
-				{
-					id: "612E94A7DE9AF1CD"
-					item: "gtceu:iv_sensor"
-					type: "item"
-				}
-			]
+				type: "item"
+			}]
 			x: 12.0d
 			y: 15.0d
 		}
@@ -1738,7 +1754,11 @@
 			y: 6.5d
 		}
 		{
-			dependencies: ["62704CC3038F1B20"]
+			dependencies: [
+				"62704CC3038F1B20"
+				"408A7D4D16AE22DF"
+			]
+			dependency_requirement: "one_completed"
 			id: "48E481BA1662E0F6"
 			rewards: [{
 				id: "2EEBBD13DF2B7483"
@@ -1754,7 +1774,11 @@
 			y: 18.5d
 		}
 		{
-			dependencies: ["7B6D059D211A42FC"]
+			dependencies: [
+				"7B6D059D211A42FC"
+				"00BC46C041564109"
+			]
+			dependency_requirement: "one_completed"
 			id: "0540B5F9B83518AD"
 			rewards: [{
 				id: "1AB766247A8034B9"
@@ -1977,6 +2001,39 @@
 			}]
 			x: 5.5d
 			y: 5.5d
+		}
+		{
+			description: ["You can get your Tantalum from lava with Tantalite as well - so if you do this checkmark this Quest to unlock the ABS!"]
+			id: "711FD6000148A2CE"
+			tasks: [{
+				id: "32645EBB35A244BC"
+				title: "Tantalum - the hard way"
+				type: "checkmark"
+			}]
+			x: 9.5d
+			y: 7.0d
+		}
+		{
+			description: ["You could also centrifuge Redstone Dust....if you don't wanna go for the Star Extractor yet"]
+			id: "00BC46C041564109"
+			tasks: [{
+				id: "70BB58B182EEFD19"
+				title: "Mercury from Redstone"
+				type: "checkmark"
+			}]
+			x: -1.5d
+			y: 13.0d
+		}
+		{
+			description: ["If you don't wanna go for PBI (or you're too broke for it) then go for some other ways to obtain Raw Carbon Fibers!"]
+			id: "408A7D4D16AE22DF"
+			tasks: [{
+				id: "3557BF9A70CAFCBB"
+				title: "Other Ways?"
+				type: "checkmark"
+			}]
+			x: 6.0d
+			y: 17.5d
 		}
 	]
 	subtitle: ["Insane Voltage"]

--- a/.minecraft/config/ftbquests/quests/chapters/tier_6__luv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_6__luv.snbt
@@ -701,33 +701,38 @@
 				item: "gtmutils:doge_coin"
 				type: "item"
 			}]
-			tasks: [
-				{
-					id: "18248DFC2011C39E"
-					item: "gtceu:luv_electric_motor"
-					type: "item"
+			tasks: [{
+				id: "5AF38A57D067F864"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:luv_electric_motor"
+							}
+							{
+								Count: 1b
+								id: "gtceu:luv_electric_pump"
+							}
+							{
+								Count: 1b
+								id: "gtceu:luv_conveyor_module"
+							}
+							{
+								Count: 1b
+								id: "gtceu:luv_electric_piston"
+							}
+							{
+								Count: 1b
+								id: "gtceu:luv_robot_arm"
+							}
+						]
+					}
 				}
-				{
-					id: "5EA69BB06A4B97ED"
-					item: "gtceu:luv_electric_pump"
-					type: "item"
-				}
-				{
-					id: "42C3EC7519E592AA"
-					item: "gtceu:luv_conveyor_module"
-					type: "item"
-				}
-				{
-					id: "74711C660EE06891"
-					item: "gtceu:luv_electric_piston"
-					type: "item"
-				}
-				{
-					id: "5B68E6D0EA004927"
-					item: "gtceu:luv_robot_arm"
-					type: "item"
-				}
-			]
+				type: "item"
+			}]
 			title: "Yeah, you like this."
 			x: 9.0d
 			y: 1.5d
@@ -740,18 +745,26 @@
 				item: "gtmutils:doge_coin"
 				type: "item"
 			}]
-			tasks: [
-				{
-					id: "49902449E1E4FFF4"
-					item: "gtceu:luv_sensor"
-					type: "item"
+			tasks: [{
+				id: "0A78DD149E53CE57"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:luv_sensor"
+							}
+							{
+								Count: 1b
+								id: "gtceu:luv_emitter"
+							}
+						]
+					}
 				}
-				{
-					id: "316756B5B96FCF64"
-					item: "gtceu:luv_emitter"
-					type: "item"
-				}
-			]
+				type: "item"
+			}]
 			title: "Damn, I don't need anything weird?"
 			x: 12.5d
 			y: 1.5d

--- a/.minecraft/config/ftbquests/quests/chapters/tier_7__zpm.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_7__zpm.snbt
@@ -123,33 +123,38 @@
 				item: "gtmutils:doge_coin"
 				type: "item"
 			}]
-			tasks: [
-				{
-					id: "4CC2AEEEC471EC61"
-					item: "gtceu:zpm_conveyor_module"
-					type: "item"
+			tasks: [{
+				id: "6F6A883DC68BCBD2"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:zpm_electric_motor"
+							}
+							{
+								Count: 1b
+								id: "gtceu:zpm_electric_pump"
+							}
+							{
+								Count: 1b
+								id: "gtceu:zpm_conveyor_module"
+							}
+							{
+								Count: 1b
+								id: "gtceu:zpm_electric_piston"
+							}
+							{
+								Count: 1b
+								id: "gtceu:zpm_robot_arm"
+							}
+						]
+					}
 				}
-				{
-					id: "1EFCE5867ABDD84C"
-					item: "gtceu:zpm_electric_motor"
-					type: "item"
-				}
-				{
-					id: "394C15520F93B203"
-					item: "gtceu:zpm_electric_piston"
-					type: "item"
-				}
-				{
-					id: "2DED68607D4342B3"
-					item: "gtceu:zpm_electric_pump"
-					type: "item"
-				}
-				{
-					id: "39F98AD4DBD3F070"
-					item: "gtceu:zpm_robot_arm"
-					type: "item"
-				}
-			]
+				type: "item"
+			}]
 			title: "Finally, ZPM"
 			x: 2.0d
 			y: 6.0d
@@ -220,18 +225,26 @@
 				item: "gtmutils:doge_coin"
 				type: "item"
 			}]
-			tasks: [
-				{
-					id: "482F8F7BAB05E126"
-					item: "gtceu:zpm_sensor"
-					type: "item"
+			tasks: [{
+				id: "3E8A7FB29C3B0B5D"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:zpm_sensor"
+							}
+							{
+								Count: 1b
+								id: "gtceu:zpm_emitter"
+							}
+						]
+					}
 				}
-				{
-					id: "6726A4E8EEE5A47E"
-					item: "gtceu:zpm_emitter"
-					type: "item"
-				}
-			]
+				type: "item"
+			}]
 			title: "ZPM Sensor \\& Emitter"
 			x: 2.0d
 			y: 8.0d

--- a/.minecraft/config/ftbquests/quests/chapters/tier_8__uv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_8__uv.snbt
@@ -48,33 +48,38 @@
 				item: "gtmutils:doge_coin"
 				type: "item"
 			}]
-			tasks: [
-				{
-					id: "0E347298E2FDE845"
-					item: "gtceu:uv_electric_motor"
-					type: "item"
+			tasks: [{
+				id: "7974B623B3CBA4DA"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:uv_electric_motor"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uv_electric_pump"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uv_conveyor_module"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uv_electric_piston"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uv_robot_arm"
+							}
+						]
+					}
 				}
-				{
-					id: "4384D174551311CF"
-					item: "gtceu:uv_electric_pump"
-					type: "item"
-				}
-				{
-					id: "19B8B861EA67B9DF"
-					item: "gtceu:uv_conveyor_module"
-					type: "item"
-				}
-				{
-					id: "6EFBD438114F52E2"
-					item: "gtceu:uv_robot_arm"
-					type: "item"
-				}
-				{
-					id: "58B8006624DC9615"
-					item: "gtceu:uv_electric_piston"
-					type: "item"
-				}
-			]
+				type: "item"
+			}]
 			title: "You love this"
 			x: -0.5d
 			y: 4.0d

--- a/.minecraft/config/ftbquests/quests/chapters/tier_9__uhv.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier_9__uhv.snbt
@@ -5,7 +5,7 @@
 	group: "6B3EFCC5BFD49997"
 	icon: "gtceu:neutronium_ingot"
 	id: "5BDBF9992074CC3A"
-	order_index: 13
+	order_index: 12
 	quest_links: [
 		{
 			id: "35A4E45F1F9D5129"
@@ -657,33 +657,38 @@
 				item: "gtmutils:doge_coin"
 				type: "item"
 			}]
-			tasks: [
-				{
-					id: "1234FC8C6807F45A"
-					item: "gtceu:uhv_electric_motor"
-					type: "item"
+			tasks: [{
+				id: "6225C7B1AB751645"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:uhv_electric_motor"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uhv_electric_pump"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uhv_conveyor_module"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uhv_electric_piston"
+							}
+							{
+								Count: 1b
+								id: "gtceu:uhv_robot_arm"
+							}
+						]
+					}
 				}
-				{
-					id: "65FE6E9075D72AED"
-					item: "gtceu:uhv_electric_pump"
-					type: "item"
-				}
-				{
-					id: "4DB129468B61860B"
-					item: { Count: 64, id: "gtceu:uhv_conveyor_module" }
-					type: "item"
-				}
-				{
-					id: "03E48C972C035003"
-					item: "gtceu:uhv_electric_piston"
-					type: "item"
-				}
-				{
-					id: "6EDB345805BB74B7"
-					item: "gtceu:uhv_robot_arm"
-					type: "item"
-				}
-			]
+				type: "item"
+			}]
 			title: "You know this, and you like it"
 			x: 11.0d
 			y: 11.5d

--- a/.minecraft/config/ftbquests/quests/chapters/tier__ev.snbt
+++ b/.minecraft/config/ftbquests/quests/chapters/tier__ev.snbt
@@ -199,6 +199,7 @@
 			y: 3.5d
 		}
 		{
+			description: ["You can use Fuel or Diesel whatever you like more!"]
 			icon: "ad_astra:fuel_bucket"
 			id: "3BCDF0F1CC18328C"
 			rewards: [{
@@ -208,12 +209,17 @@
 			}]
 			tasks: [
 				{
-					id: "172486CFF8F34250"
-					item: "gtceu:hv_distillery"
+					id: "5D58F379B6076301"
+					type: "checkmark"
+				}
+				{
+					id: "7B817EE6877A0D1F"
+					item: "gtceu:diesel_bucket"
+					optional_task: true
 					type: "item"
 				}
 				{
-					id: "6FD06B2F2DCB881B"
+					id: "55743495A87E80B0"
 					item: "ad_astra:fuel_bucket"
 					type: "item"
 				}
@@ -398,33 +404,38 @@
 				item: "gtmutils:doge_coin"
 				type: "item"
 			}]
-			tasks: [
-				{
-					id: "342AAAB7F4DB7C19"
-					item: "gtceu:ev_electric_motor"
-					type: "item"
+			tasks: [{
+				id: "2974AB7915948F68"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:ev_electric_motor"
+							}
+							{
+								Count: 1b
+								id: "gtceu:ev_electric_pump"
+							}
+							{
+								Count: 1b
+								id: "gtceu:ev_conveyor_module"
+							}
+							{
+								Count: 1b
+								id: "gtceu:ev_electric_piston"
+							}
+							{
+								Count: 1b
+								id: "gtceu:ev_robot_arm"
+							}
+						]
+					}
 				}
-				{
-					id: "2C42637FA0C91F7E"
-					item: "gtceu:ev_electric_pump"
-					type: "item"
-				}
-				{
-					id: "2F03C497A4404960"
-					item: "gtceu:ev_conveyor_module"
-					type: "item"
-				}
-				{
-					id: "22DB81CB3CFA2047"
-					item: "gtceu:ev_electric_piston"
-					type: "item"
-				}
-				{
-					id: "17ED483117E5D87D"
-					item: "gtceu:ev_robot_arm"
-					type: "item"
-				}
-			]
+				type: "item"
+			}]
 			title: "I dont think you hate this anymore."
 			x: 10.5d
 			y: 11.5d
@@ -1466,7 +1477,6 @@
 		{
 			dependencies: [
 				"56A354EB0D7C0ACE"
-				"63E6C9DB9DFBCFBD"
 				"700D75AB04659866"
 			]
 			description: [
@@ -1539,18 +1549,26 @@
 				type: "item"
 			}]
 			subtitle: "Don't worry, IV ones are even more annoying"
-			tasks: [
-				{
-					id: "1F41E3853F064491"
-					item: "gtceu:ev_emitter"
-					type: "item"
+			tasks: [{
+				id: "1826663727B067CA"
+				item: {
+					Count: 1
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "gtceu:ev_emitter"
+							}
+							{
+								Count: 1b
+								id: "gtceu:ev_sensor"
+							}
+						]
+					}
 				}
-				{
-					id: "1C9C608693F85011"
-					item: "gtceu:ev_sensor"
-					type: "item"
-				}
-			]
+				type: "item"
+			}]
 			title: "You sure hate those."
 			x: 13.5d
 			y: 3.0d
@@ -1728,7 +1746,7 @@
 				type: "item"
 			}]
 			tasks: [{
-				id: "13A2DFDD9A8F9A43"
+				id: "64E6C90E4523A9C3"
 				item: {
 					Count: 1
 					id: "itemfilters:or"
@@ -1736,11 +1754,11 @@
 						items: [
 							{
 								Count: 1b
-								id: "gtceu:endstone_tungstate_ore"
+								id: "gtceu:raw_scheelite"
 							}
 							{
 								Count: 1b
-								id: "gtceu:endstone_scheelite_ore"
+								id: "gtceu:raw_tungstate"
 							}
 						]
 					}


### PR DESCRIPTION
Changed a lot of Quests for some better experience
Changed that UHV and UEV is in the right order as well (it was first UEV then UHV in the tab menu)

Special thanks to @wesselvl1 for the first PR to give some more input to the fixes I wanted to do anyways!

That's the changelog for everything:

Quest Changes:
	LV-UIV
		- Changed all Component-Quests to and OR-Filter, so you only need one of the components, not all of them
	Steam-Age
		- Added a Quest for the Steam Foundry 
	LV
		- Changed Description from Gas Collector Quest for people who don't know to get Oxygen the first time for lapis
		- Changed the Ink Sac and HNN Quest Part to fit better
	MV
		- Added an OR-Filter to the Distillery and Rock Crusher Quests
		- Added a new OR-Filter Dependency for the "Batchcraft this" (Monocrystalline Silicon Boule Quest) so you won't need the stone/clay line anymore
	HV
		- Deleted Cleanroom and HV Components Dependencies from the LPIC Wafer Quest
		- Added Cleanroom Dependency to the LPIC Chip Quest
		- Change Quest Item from HV Centrifuge to HV Electrolyzer cause we changed the Phosphorus Recipe to electrolyzer back then
		- Adding 8x Filter Casings to the Cleanroom Quest cause that's the minimum
		- Also changed the HV Diode to an OR-Filter to use any diode in it and make it optional cause theoretically you could use solars in it^
		- Deleted the platinum ingot dependency from the cleanroom quest as well cause if you won't use a HV diode you won't need it
		- Added a quest to mention Nickel Processing for getting platinum dust which is just a checkmark so you don't have to do the others if not wanted
		- Added a quest for the Auto-Maintenance Hatch so people won't eventually miss it
		- Deleted the HV Mixer dependency from the Black Steel Dust Quest cause even LV would be enough
		- Switched the HV Laser Engraver + HV Cutter Quest to be an OR as well
		- "Liquid Blaze when" Quest - changed the Red Steel Gears to being consumed as well
		- Fixed Typo in "Polyethelen" Quest
		- Added a new quest if you do the sulfuric acid in the LCR-way instead of singleblock Chemical Reactors
		- Added a new quest to mention you could use PVC or PTFE for the Circuit Boards as well
		- Changed the Circuit Board Quest to need 2 from the 4 Dependencies so you can only use the 2 checkmark ones instead
		- Switched the position from some HV machine quests at the right to fit a bit better
	EV
		- Changed the tungsten ores quest to raw tungstate OR raw scheelite instead of the actual ore blocks
		- Deleting the HV Distillery from the Rocket Fuel Quest, making Fuel optional also adding optional Diesel and making it a checkmark quest
		- Deleting Laminated Glass Quest as a dependency for the IV Input Hatch Quest
	IV
		- Added a new Quest for mentioning Tantalum from Lava as a checkmark
		- Changed ABS Quest to need 3 Quests so instead of the need for the Star Extractor etc you can only do the 2 Ingot Quests + the Tantalum Checkmark
		- Added a quest to mention Mercury from Redstone (Checkmark)
		- Changed the mercury quest to need only the checkmark quest OR star extractor
		- Added a quest to mention other ways except PBI for Raw Carbon Fibers
		- Make only checkmark OR PBI quest needed for Raw Carbon Fiber
		- Nanoprocessor Quest change to only need 2 of the Quests so you won't need PBI for SMD Upgrades anymore cause you can still use old SMDs
	UXV
		- Added 2 Quests for the UXV Components
	Shop
		- Deleting the Copper Credit Quest