### PR TITLE
Spatial_flux

### DIFF
--- a/.minecraft/kubejs/server_scripts/mainlines/pcb.js
+++ b/.minecraft/kubejs/server_scripts/mainlines/pcb.js
@@ -309,7 +309,7 @@ ServerEvents.recipes(event => {
             .itemInputs('64x kubejs:ultra_stable_cosmic_strings')
             .outputFluids('gtceu:spatial_flux 100')
             .duration(20*25)
-            .EUt(GTValues.VA[GTValues.OpV])
+            .EUt(GTValues.VA[GTValues.UXV])
 
         event.recipes.gtceu.stasis_phase_shifter('stabilized_spatial_flux')
             .inputFluids('gtceu:spatial_flux 10000', "advanced_ae:quantum_infusion_source 2500")

--- a/.minecraft/kubejs/server_scripts/mainlines/pcb.js
+++ b/.minecraft/kubejs/server_scripts/mainlines/pcb.js
@@ -309,7 +309,7 @@ ServerEvents.recipes(event => {
             .itemInputs('64x kubejs:ultra_stable_cosmic_strings')
             .outputFluids('gtceu:spatial_flux 100')
             .duration(20*25)
-            .EUt(GTValues.VA[GTValues.UXV])
+            .EUt(GTValues.VA[GTValues.OpV])
 
         event.recipes.gtceu.stasis_phase_shifter('stabilized_spatial_flux')
             .inputFluids('gtceu:spatial_flux 10000', "advanced_ae:quantum_infusion_source 2500")

--- a/.minecraft/kubejs/startup_scripts/multiblocks/robust_extractinator.js
+++ b/.minecraft/kubejs/startup_scripts/multiblocks/robust_extractinator.js
@@ -20,7 +20,7 @@ GTCEuStartupEvents.registry('gtceu:machine', event => {
                   .or(Predicates.abilities(PartAbility.PARALLEL_HATCH))
                   .or(Predicates.abilities(PartAbility.EXPORT_ITEMS, PartAbility.IMPORT_ITEMS, PartAbility.EXPORT_FLUIDS, PartAbility.IMPORT_FLUIDS))
                   .or(Predicates.abilities(PartAbility.MAINTENANCE).setExactLimit(1))
-                  .or(Predicates.abilities(PartAbility.INPUT_ENERGY).setExactLimit(1))
+                  .or(Predicates.abilities(PartAbility.INPUT_ENERGY))
             )
             .where('#', Predicates.any())
             .build()


### PR DESCRIPTION
Since it is only possible to install 1 energy input hatch in this multiblock, this liquid cannot be crafted until OPV hatches appear, this commit makes it possible on the UXV, and makes crafting possible pcb mk3.