### PR TITLE
Various Changes

### DIFF
--- a/.minecraft/kubejs/assets/gtceu/lang/en_us.json
+++ b/.minecraft/kubejs/assets/gtceu/lang/en_us.json
@@ -1,5 +1,4 @@
 {
-    "material.gtceu.indium_tin_barium_titanium_cuprate": "Tetraindiumditindibariumtitaniumheptacoppertetrakaidekaoxide",
     "block.gtceu.draconium_assembly_line": "Draconium Assembly Line",
     "block.gtceu.collosal_laser_beam_containment_chamber":"Collosal Laser Beam Containment Chamber",
 	"block.gtceu.extreme_cracking_unit": "Extreme Cracking Unit",

--- a/.minecraft/kubejs/assets/gtceu/models/item/material_sets/cosmic_matter/wire_fine.json
+++ b/.minecraft/kubejs/assets/gtceu/models/item/material_sets/cosmic_matter/wire_fine.json
@@ -1,6 +1,7 @@
 {
-  "parent": "item/handheld",
+  "parent": "item/generated",
   "textures": {
-    "layer0": "gtceu:item/material_sets/cosmic_matter/wire_fine"
+    "layer0": "gtceu:item/material_sets/cosmic_matter/wire_fine",
+    "layer1": "gtceu:item/material_sets/cosmic_matter/wire_fine_overlay"
   }
 }

--- a/.minecraft/kubejs/assets/gtceu/models/item/material_sets/eternity/wire_fine.json
+++ b/.minecraft/kubejs/assets/gtceu/models/item/material_sets/eternity/wire_fine.json
@@ -1,6 +1,7 @@
 {
-  "parent": "item/handheld",
+  "parent": "item/generated",
   "textures": {
-    "layer0": "gtceu:item/material_sets/eternity/wire_fine"
+    "layer0": "gtceu:item/material_sets/eternity/wire_fine",
+    "layer1": "gtceu:item/material_sets/eternity/wire_fine_overlay"
   }
 }

--- a/.minecraft/kubejs/assets/gtceu/models/item/material_sets/stellar_matter/wire_fine.json
+++ b/.minecraft/kubejs/assets/gtceu/models/item/material_sets/stellar_matter/wire_fine.json
@@ -1,6 +1,7 @@
 {
-  "parent": "item/handheld",
+  "parent": "item/generated",
   "textures": {
-    "layer0": "gtceu:item/material_sets/stellar_matter/wire_fine"
+    "layer0": "gtceu:item/material_sets/stellar_matter/wire_fine",
+    "layer1": "gtceu:item/material_sets/stellar_matter/wire_fine_overlay"
   }
 }

--- a/.minecraft/kubejs/assets/gtceu/models/item/material_sets/universium/wire_fine.json
+++ b/.minecraft/kubejs/assets/gtceu/models/item/material_sets/universium/wire_fine.json
@@ -1,6 +1,7 @@
 {
-  "parent": "item/handheld",
+  "parent": "item/generated",
   "textures": {
-    "layer0": "gtceu:item/material_sets/universium/wire_fine"
+    "layer0": "gtceu:item/material_sets/universium/wire_fine",
+    "layer1": "gtceu:item/material_sets/universium/wire_fine_overlay"
   }
 }

--- a/.minecraft/kubejs/server_scripts/assline/components/extra.js
+++ b/.minecraft/kubejs/server_scripts/assline/components/extra.js
@@ -4,116 +4,191 @@
 
 
 ServerEvents.recipes(event => {
-    const converter = [
-        ['uev', 'cosmic_neutronium', 'draconium', '33554432'],
-        ['uiv', 'awakened_draconium', 'chaos', '134217728'],
-    ]
     const transformer = [
         ['uhv', 'ruthenium_trinium_americium_neutronate', 'crystal_matrix'],
         ['uev', 'cosmic_neutronium', 'draconium'],
         ['uiv', 'awakened_draconium', 'chaos'],
         ['uxv', 'chaos', 'chaos'],
     ]
+
+    transformer.forEach(([tier, mat1, mat2]) => {
+        event.shaped(Item.of(`gtceu:${tier}_transformer_1a`), [
+            'WBB',
+            'AH ',
+            'WBB'
+        ], {
+            A: `gtceu:${mat1}_single_wire`,
+            B: `gtceu:${mat2}_single_wire`,
+            H: `gtceu:${tier}_machine_hull`,
+            W: 'kubejs:highly_resonative_soc'
+        })
+        event.shaped(Item.of(`gtceu:${tier}_transformer_2a`), [
+            'WBB',
+            'AH ',
+            'WBB'
+        ], {
+            A: `gtceu:${mat1}_double_wire`,
+            B: `gtceu:${mat2}_double_wire`,
+            H: `gtceu:${tier}_machine_hull`,
+            W: 'kubejs:highly_resonative_soc'
+        })
+        event.shaped(Item.of(`gtceu:${tier}_transformer_4a`), [
+            'WBB',
+            'AH ',
+            'WBB'
+        ], {
+            A: `gtceu:${mat1}_quadruple_wire`,
+            B: `gtceu:${mat2}_quadruple_wire`,
+            H: `gtceu:${tier}_machine_hull`,
+            W: 'kubejs:highly_resonative_soc'
+        })
+        event.shaped(Item.of(`gtceu:${tier}_transformer_16a`), [
+            'WBB',
+            'AH ',
+            'WBB'
+        ], {
+            A: `gtceu:${mat1}_hex_wire`,
+            B: `gtceu:${mat2}_hex_wire`,
+            H: `gtceu:${tier}_machine_hull`,
+            W: 'kubejs:highly_resonative_soc'
+        })
+    })
+
+    // UEV+ Transformers
+    event.remove({ id: "gtceu:assembler/uev_transformer" })
+    event.remove({ id: "gtceu:assembler/uev_hi_amp_2a_transformer" })
+    event.remove({ id: "gtceu:assembler/uev_hi_amp_4a_transformer" })
+    event.remove({ id: "gtceu:assembler/uev_power_transformer" })
+    event.remove({ id: "gtceu:assembler/uiv_transformer" })
+    event.remove({ id: "gtceu:assembler/uiv_hi_amp_2a_transformer" })
+    event.remove({ id: "gtceu:assembler/uiv_hi_amp_4a_transformer" })
+    event.remove({ id: "gtceu:assembler/uiv_power_transformer" })
+    event.remove({ id: "gtceu:assembler/uxv_transformer" })
+    event.remove({ id: "gtceu:assembler/uxv_hi_amp_2a_transformer" })
+    event.remove({ id: "gtceu:assembler/uxv_hi_amp_4a_transformer" })
+    event.remove({ id: "gtceu:assembler/uxv_power_transformer" })
+        
+    const transformerTiers = [
+        ["uev", "draconium", "cosmic_neutronium", "cosmic_neutronium"],
+        ["uiv", "awakened_draconium", "chaos", "awakened_draconium"],
+        ["uxv", "awakened_draconium", "hypoxylon", "heavy_duty_alloy_t4"]
+    ];
+
+    transformerTiers.forEach(([tier, wireA, wireB, spring]) => {
+        const lowercasetier = tier.toLowerCase();
+        const energytier = GTValues.VA[GTValues[tier.toUpperCase()]];
+
+        event.recipes.gtceu.assembler(`${lowercasetier}_transformer`)
+            .itemInputs(
+                `1x gtceu:${lowercasetier}_machine_hull`,
+                `1x gtceu:${wireA}_single_wire`,
+                `4x gtceu:${wireB}_single_wire`,
+                "2x kubejs:highly_resonative_soc")
+            .itemOutputs(
+                `gtceu:${lowercasetier}_transformer_1a`)
+            .duration(20*5)
+            .EUt(energytier);
+
+        event.recipes.gtceu.assembler(`${lowercasetier}_hi_amp_2a_transformer`)
+            .itemInputs(
+                `1x gtceu:${lowercasetier}_transformer_1a`,
+                `1x gtceu:${wireA}_double_wire`,
+                `4x gtceu:${wireB}_double_wire`,
+                "2x kubejs:highly_resonative_soc")
+            .itemOutputs(
+                `gtceu:${lowercasetier}_transformer_2a`)
+            .duration(20*5)
+            .EUt(energytier);
+
+        event.recipes.gtceu.assembler(`${lowercasetier}_hi_amp_4a_transformer`)
+            .itemInputs(
+                `1x gtceu:${lowercasetier}_transformer_1a`,
+                `1x gtceu:${wireA}_quadruple_wire`,
+                `4x gtceu:${wireB}_quadruple_wire`,
+                "2x kubejs:highly_resonative_soc")
+            .itemOutputs(
+                `gtceu:${lowercasetier}_transformer_4a`)
+            .duration(20*5)
+            .EUt(energytier);
+
+        event.recipes.gtceu.assembler(`${lowercasetier}_power_transformer`)
+            .itemInputs(
+                `1x gtceu:${lowercasetier}_transformer_4a`,
+                `1x gtceu:${lowercasetier}_electric_pump`,
+                `1x gtceu:${wireA}_octal_cable`,
+                `1x gtceu:${wireA}_hex_cable`,
+                `1x gtceu:small_${spring}_spring`,
+                `1x gtceu:${spring}_spring`)
+            .inputFluids(
+                "gtceu:lubricant 2000")
+            .itemOutputs(
+                `gtceu:${lowercasetier}_transformer_16a`)
+            .duration(20*5)
+            .EUt(energytier);
+        });
+
+
+    // OpV Transformers
+
+    event.remove({ id: "gtceu:assembler/opv_transformer" })
+    event.remove({ id: "gtceu:assembler/opv_hi_amp_2a_transformer" })
+    event.remove({ id: "gtceu:assembler/opv_hi_amp_4a_transformer" })
+    event.remove({ id: "gtceu:assembler/opv_power_transformer" })
+
+    event.recipes.gtceu.assembler("opv_transformer")
+        .itemInputs(
+            "1x gtceu:opv_machine_hull",
+            "1x gtceu:awakened_draconium_single_wire",
+            "4x gtceu:cosmic_neutronium_single_wire",
+            "2x kubejs:highly_resonative_soc")
+        .itemOutputs(
+            "gtceu:opv_transformer_1a")
+        .duration(20*5)
+        .EUt((GTValues.VA[GTValues.OpV]));
+
+        event.recipes.gtceu.assembler("opv_hi_amp_2a_transformer")
+            .itemInputs(
+                "1x gtceu:opv_transformer_1a",
+                "1x gtceu:awakened_draconium_double_wire",
+                "4x gtceu:cosmic_neutronium_double_wire",
+                "2x kubejs:highly_resonative_soc")
+            .itemOutputs(
+                "gtceu:opv_transformer_2a")
+            .duration(20*5)
+            .EUt((GTValues.VA[GTValues.OpV]));
+
+        event.recipes.gtceu.assembler("opv_hi_amp_4a_transformer")
+            .itemInputs(
+                "1x gtceu:opv_transformer_1a",
+                "1x gtceu:awakened_draconium_quadruple_wire",
+                "4x gtceu:cosmic_neutronium_quadruple_wire",
+                "2x kubejs:highly_resonative_soc")
+            .itemOutputs(
+                "gtceu:opv_transformer_4a")
+            .duration(20*5)
+            .EUt((GTValues.VA[GTValues.OpV]));
+
+        event.recipes.gtceu.assembler("opv_power_transformer")
+            .itemInputs(
+                "1x gtceu:opv_transformer_4a",
+                "1x gtceu:opv_electric_pump",
+                "1x gtceu:awakened_draconium_octal_cable",
+                "1x gtceu:awakened_draconium_hex_cable",
+                "1x gtceu:small_cosmic_neutronium_spring",
+                "1x gtceu:cosmic_neutronium_spring")
+            .inputFluids(
+                "gtceu:lubricant 2000")
+            .itemOutputs(
+                "gtceu:opv_transformer_16a")
+            .duration(20*5)
+            .EUt((GTValues.VA[GTValues.OpV]));
+
+
     // no MAX tier laserhatch :1984:
     const laserhatch = [
         ['uev', 'draconium', '1966080'],
         ['uiv', 'awakened_draconium', '3932160'],
     ]
-
-        converter.forEach(([tier, mat1, mat2, eut]) => {
-            event.remove({ output:[`gtceu:${tier}_1a_energy_converter`, `gtceu:${tier}_4a_energy_converter`, `gtceu:${tier}_8a_energy_converter`, `gtceu:${tier}_16a_energy_converter` ] })
-            event.shaped(Item.of(`gtceu:${tier}_1a_energy_converter`), [
-                ' BB',
-                'AHC',
-                ' BB'
-            ], {
-                A: `gtceu:red_alloy_single_wire`,
-                B: `gtceu:${mat2}_single_wire`,
-                H: `gtceu:${tier}_machine_hull`,
-                C: `#gtceu:circuits/${tier}`
-            })
-
-
-            event.shaped(Item.of(`gtceu:${tier}_4a_energy_converter`), [
-                ' BB',
-                'AHC',
-                ' BB'
-            ], {
-                A: `gtceu:red_alloy_quadruple_wire`,
-                B: `gtceu:${mat2}_quadruple_wire`,
-                H: `gtceu:${tier}_machine_hull`,
-                C: `#gtceu:circuits/${tier}`
-            })
-
-            event.shaped(Item.of(`gtceu:${tier}_8a_energy_converter`), [
-                ' BB',
-                'AHC',
-                ' BB'
-            ], {
-                A: `gtceu:red_alloy_octal_wire`,
-                B: `gtceu:${mat2}_octal_wire`,
-                H: `gtceu:${tier}_machine_hull`,
-                C: `#gtceu:circuits/${tier}`
-            })
-
-            event.shaped(Item.of(`gtceu:${tier}_16a_energy_converter`), [
-                ' BB',
-                'AHC',
-                ' BB'
-            ], {
-                A: `gtceu:red_alloy_hex_wire`,
-                B: `gtceu:${mat2}_hex_wire`,
-                H: `gtceu:${tier}_machine_hull`,
-                C: `#gtceu:circuits/${tier}`
-            })
-        })
-
-        transformer.forEach(([tier, mat1, mat2]) => {
-            event.shaped(Item.of(`gtceu:${tier}_transformer_1a`), [
-                'WBB',
-                'AH ',
-                'WBB'
-            ], {
-                A: `gtceu:${mat1}_single_wire`,
-                B: `gtceu:${mat2}_single_wire`,
-                H: `gtceu:${tier}_machine_hull`,
-                W: 'kubejs:highly_resonative_soc'
-            })
-
-            event.shaped(Item.of(`gtceu:${tier}_transformer_2a`), [
-                'WBB',
-                'AH ',
-                'WBB'
-            ], {
-                A: `gtceu:${mat1}_double_wire`,
-                B: `gtceu:${mat2}_double_wire`,
-                H: `gtceu:${tier}_machine_hull`,
-                W: 'kubejs:highly_resonative_soc'
-            })
-
-            event.shaped(Item.of(`gtceu:${tier}_transformer_4a`), [
-                'WBB',
-                'AH ',
-                'WBB'
-            ], {
-                A: `gtceu:${mat1}_quadruple_wire`,
-                B: `gtceu:${mat2}_quadruple_wire`,
-                H: `gtceu:${tier}_machine_hull`,
-                W: 'kubejs:highly_resonative_soc'
-            })
-
-            event.shaped(Item.of(`gtceu:${tier}_transformer_16a`), [
-                'WBB',
-                'AH ',
-                'WBB'
-            ], {
-                A: `gtceu:${mat1}_hex_wire`,
-                B: `gtceu:${mat2}_hex_wire`,
-                H: `gtceu:${tier}_machine_hull`,
-                W: 'kubejs:highly_resonative_soc'
-            })
-        })
-
 
     laserhatch.forEach(([tier, mat1, eut]) => {
         event.recipes.gtceu.assembler(`${tier}_256a_laser_target_hatch`)
@@ -160,56 +235,63 @@ ServerEvents.recipes(event => {
     })
 
 })
-//
+
 ServerEvents.recipes(sog => {
 
+    sog.recipes.gtceu.quantum_station("qdm")
+        .inputFluids(
+            "gtceu:oganesson 32",
+            "gtceu:nihonium 32")
+        .itemInputs(
+            "gtceu:data_module")
+        .itemOutputs(
+            "kubejs:quantum_data_module")
+        .EUt((GTValues.VA[GTValues.UEV]))
+        .totalCWU(256*500)
+        .CWUt(256)
 
-    sog.recipes.gtceu.quantum_station('qdm')
-            .inputFluids('gtceu:oganesson 32', 'gtceu:nihonium 32')
-            .itemInputs('gtceu:data_module')
-            .itemOutputs('kubejs:quantum_data_module')
-            .EUt((GTValues.VA[GTValues.UEV]))
-            .totalCWU(256*500)
-            .CWUt(256)
+    sog.recipes.gtceu.hgim("kubejs:space_time_heavy_plating")
+        .notConsumable(
+            "kubejs:gravitational_containment_cell")
+        .itemInputs(
+            "7x gtceu:dense_hypoxylon_plate",
+            "kubejs:quantum_energy_capsule")
+        .itemInputs(
+            "31x gtceu:double_space_time_plate")
+        .inputFluids(
+            "gtceu:nihonium 144*16",
+            "gtceu:oganesson 144*16")
+        .itemOutputs(
+            "kubejs:space_time_heavy_plating")
+        .EUt(GTValues.VA[GTValues.UIV])
+        .duration(20*60)
 
-                sog.recipes.gtceu.hgim("kubejs:space_time_heavy_plating")
-                .notConsumable('kubejs:gravitational_containment_cell')
-                .itemInputs('7x gtceu:dense_hypoxylon_plate', 'kubejs:quantum_energy_capsule')
-                .itemInputs("31x gtceu:double_space_time_plate")
-                .inputFluids("gtceu:nihonium 144*16", "gtceu:oganesson 144*16")
-                .itemOutputs("kubejs:space_time_heavy_plating")
-                .EUt(GTValues.VA[GTValues.UIV])
-                .duration(20*60)
+    sog.recipes.gtceu.extruder("nan_certificate")
+        .itemInputs(
+            "64x gtceu:dense_infinity_plate")
+        .itemInputs(
+            "64x gtceu:dense_infinity_plate")
+        .itemOutputs(
+            "gtceu:nan_certificate")
+        .duration(3600*20*2)
+        .EUt((GTValues.VA[GTValues.OpV]))
 
-                sog.recipes.gtceu.extruder('nan_certificate')
-                .itemInputs('64x gtceu:dense_infinity_plate')
-                .itemInputs('64x gtceu:dense_infinity_plate')
-                .itemOutputs('gtceu:nan_certificate')
-                .duration(3600*20*2)
-                .EUt((GTValues.VA[GTValues.OpV]))
-
-
-            const plating = ["neutronium", "chaos", "infinity", "cosmic_neutronium", "draconium", "awakened_draconium", "californite", "eternity"]
-            plating.forEach((plate) => {
+    const plating = ["neutronium", "chaos", "infinity", "cosmic_neutronium", "draconium", "awakened_draconium", "californite", "eternity"]
+        plating.forEach((plate) => {
             sog.recipes.gtceu.hgim("kubejs:" + plate + "_heavy_plating")
-                .notConsumable('kubejs:gravitational_containment_cell')
-                .itemInputs('7x gtceu:dense_hypoxylon_plate', 'kubejs:quantum_energy_capsule')
-                .itemInputs("7x gtceu:dense_" + plate + "_plate")
-                .inputFluids("gtceu:nihonium 144*16", "gtceu:oganesson 144*16")
-                .itemOutputs("kubejs:" + plate + "_heavy_plating")
+                .notConsumable(
+                    "kubejs:gravitational_containment_cell")
+                .itemInputs(
+                    "7x gtceu:dense_hypoxylon_plate",
+                    "kubejs:quantum_energy_capsule")
+                .itemInputs(
+                    "7x gtceu:dense_" + plate + "_plate")
+                .inputFluids(
+                    "gtceu:nihonium 144*16",
+                    "gtceu:oganesson 144*16")
+                .itemOutputs(
+                    "kubejs:" + plate + "_heavy_plating")
                 .EUt(GTValues.VA[GTValues.UEV])
                 .duration(20*60)
-
-
         })
-
-
-
-
-
-
-
-
-
-
 })

--- a/.minecraft/kubejs/server_scripts/hnn_recipes.js
+++ b/.minecraft/kubejs/server_scripts/hnn_recipes.js
@@ -69,11 +69,11 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.IV]);
 
     event.recipes.gtceu.assembler("soul_infused_casing")
-        .circuit(6)
         .itemInputs(
             "4x enderio:soularium_pressure_plate",
             "4x minecraft:soul_sand"
         )
+        .circuit(6)
         .itemOutputs("kubejs:soul_infused_casing")
         .duration(5*45)
         .EUt(GTValues.VA[GTValues.IV]);
@@ -81,11 +81,11 @@ ServerEvents.recipes(event => {
 // Recipe Type Recipes
 
 event.recipes.gtceu.electric_simulation_chamber("spidersim")
-    .circuit(1)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:spider"}}').weakNBT())
+    .circuit(1)
 	.itemOutputs(
         "128x minecraft:string",
         "64x minecraft:spider_eye",
@@ -94,11 +94,11 @@ event.recipes.gtceu.electric_simulation_chamber("spidersim")
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("spidersim2")
-    .circuit(10)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:spider"}}').weakNBT())
+    .circuit(10)
     .itemOutputs(Item.of(
         "4x hostilenetworks:prediction",
         '{data_model:{id:"hostilenetworks:spider"}}').strongNBT())
@@ -106,11 +106,11 @@ event.recipes.gtceu.electric_simulation_chamber("spidersim2")
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("witchsim")
-    .circuit(1)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:witch"}}').weakNBT())
+    .circuit(1)
 	.itemOutputs(
         "32x minecraft:redstone",
         "32x minecraft:glowstone_dust",
@@ -122,11 +122,11 @@ event.recipes.gtceu.electric_simulation_chamber("witchsim")
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("witchsim2")
-    .circuit(10)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:witch"}}').weakNBT())
+    .circuit(10)
     .itemOutputs(Item.of(
         "2x hostilenetworks:prediction",
         '{data_model:{id:"hostilenetworks:witch"}}').strongNBT())
@@ -134,22 +134,22 @@ event.recipes.gtceu.electric_simulation_chamber("witchsim2")
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("wardensim")
-    .circuit(1)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:warden"}}').weakNBT())
+    .circuit(1)
 	.itemOutputs(
         "2x minecraft:echo_shard")
     .duration(20*75)
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("wardensim2")
-    .circuit(10)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:warden"}}').weakNBT())
+    .circuit(10)
     .itemOutputs(Item.of(
         "hostilenetworks:prediction",
         '{data_model:{id:"hostilenetworks:warden"}}').strongNBT())
@@ -157,22 +157,22 @@ event.recipes.gtceu.electric_simulation_chamber("wardensim2")
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("squidsim")
-    .circuit(1)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:squid"}}').weakNBT())
+    .circuit(1)
 	.itemOutputs(
         "512x minecraft:ink_sac")
     .duration(20*15)
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("squidsim2")
-    .circuit(10)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:squid"}}').weakNBT())
+    .circuit(10)
     .itemOutputs(Item.of(
         "16x hostilenetworks:prediction",
         '{data_model:{id:"hostilenetworks:squid"}}').strongNBT())
@@ -180,11 +180,11 @@ event.recipes.gtceu.electric_simulation_chamber("squidsim2")
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("slimesim")
-    .circuit(1)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:slime"}}').weakNBT())
+    .circuit(1)
 	.itemOutputs(
         "128x minecraft:slime_ball",
         "32x minecraft:slime_block")
@@ -192,11 +192,11 @@ event.recipes.gtceu.electric_simulation_chamber("slimesim")
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("slimesim2")
-    .circuit(10)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:slime"}}').weakNBT())
+    .circuit(10)
     .itemOutputs(Item.of(
         "4x hostilenetworks:prediction",
         '{data_model:{id:"hostilenetworks:slime"}}').strongNBT())
@@ -204,11 +204,11 @@ event.recipes.gtceu.electric_simulation_chamber("slimesim2")
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("sheepsim")
-    .circuit(1)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:sheep"}}').weakNBT())
+    .circuit(1)
 	.itemOutputs(
         "64x minecraft:white_wool",
         "64x minecraft:orange_wool",
@@ -223,11 +223,11 @@ event.recipes.gtceu.electric_simulation_chamber("sheepsim")
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("sheepsim2")
-    .circuit(2)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:sheep"}}').weakNBT())
+    .circuit(2)
 	.itemOutputs(
         "64x minecraft:cyan_wool",
         "64x minecraft:purple_wool",
@@ -241,11 +241,11 @@ event.recipes.gtceu.electric_simulation_chamber("sheepsim2")
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("sheepsim3")
-    .circuit(10)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:sheep"}}').weakNBT())
+    .circuit(10)
     .itemOutputs(Item.of(
         "8x hostilenetworks:prediction",
         '{data_model:{id:"hostilenetworks:sheep"}}').strongNBT())
@@ -253,11 +253,11 @@ event.recipes.gtceu.electric_simulation_chamber("sheepsim3")
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("endermansim")
-    .circuit(1)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:enderman"}}').weakNBT())
+    .circuit(1)
 	.itemOutputs(
         "16x minecraft:ender_pearl",
         "1x minecraft:end_crystal")
@@ -265,11 +265,11 @@ event.recipes.gtceu.electric_simulation_chamber("endermansim")
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("endermansim2")
-    .circuit(10)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:enderman"}}').weakNBT())
+    .circuit(10)
     .itemOutputs(Item.of(
         "hostilenetworks:prediction",
         '{data_model:{id:"hostilenetworks:enderman"}}').strongNBT())
@@ -277,11 +277,11 @@ event.recipes.gtceu.electric_simulation_chamber("endermansim2")
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("enderdragonsim")
-    .circuit(1)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:ender_dragon"}}').weakNBT())
+    .circuit(1)
 	.itemOutputs(
         "16x minecraft:dragon_breath",
         "1x minecraft:dragon_egg")
@@ -289,11 +289,11 @@ event.recipes.gtceu.electric_simulation_chamber("enderdragonsim")
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("enderdragonsim2")
-    .circuit(10)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:ender_dragon"}}').weakNBT())
+    .circuit(10)
     .itemOutputs(Item.of(
         "hostilenetworks:prediction",
         '{data_model:{id:"hostilenetworks:ender_dragon"}}').strongNBT())
@@ -301,11 +301,11 @@ event.recipes.gtceu.electric_simulation_chamber("enderdragonsim2")
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("elderguardiansim")
-    .circuit(1)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:elder_guardian"}}').weakNBT())
+    .circuit(1)
 	.itemOutputs(
         "16x minecraft:cod",
         "2x minecraft:salmon",
@@ -318,11 +318,11 @@ event.recipes.gtceu.electric_simulation_chamber("elderguardiansim")
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("elderguardiansim2")
-    .circuit(10)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:elder_guardian"}}').weakNBT())
+    .circuit(10)
     .itemOutputs(Item.of(
         "hostilenetworks:prediction",
         '{data_model:{id:"hostilenetworks:elder_guardian"}}').strongNBT())
@@ -330,22 +330,22 @@ event.recipes.gtceu.electric_simulation_chamber("elderguardiansim2")
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("blazesim")
-    .circuit(1)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:blaze"}}').weakNBT())
+    .circuit(1)
 	.itemOutputs(
         "32x minecraft:blaze_rod")
     .duration(20*15)
     .EUt(GTValues.VA[GTValues.MV]);
 
 event.recipes.gtceu.electric_simulation_chamber("blazesim2")
-    .circuit(10)
     .notConsumable(
         Item.of(
             "hostilenetworks:data_model",
             '{data_model:{id:"hostilenetworks:blaze"}}').weakNBT())
+    .circuit(10)
     .itemOutputs(Item.of(
         "2x hostilenetworks:prediction",
         '{data_model:{id:"hostilenetworks:blaze"}}').strongNBT())

--- a/.minecraft/kubejs/server_scripts/mainlines/gregification.js
+++ b/.minecraft/kubejs/server_scripts/mainlines/gregification.js
@@ -1,2574 +1,2442 @@
 ServerEvents.recipes(sog => {
-    sog.recipes.gtceu.compressor('diamondcompressing')
+    // Random Stuff
+
+    exdeorum.setCrucibleHeatValueForState("minecraft:lightning_rod", 80);
+
+    
+    // Replacings
+
+    sog.replaceInput( {id: "gtceu:assembly_line/electric_pump_uv"},
+        "gtceu:silicone_rubber_ring",
+        "gtceu:neoprene_ring")
+
+    sog.replaceInput( {id: "gtceu:assembly_line/conveyor_module_uv"},
+        "gtceu:styrene_butadiene_rubber",
+        "gtceu:neoprene")
+        
+
+    // Auto Turbo Chargers UEV+
+
+    const autoChargerWires = [
+        ["uev", "kaemite"],
+        ["uiv", "awakened_draconium"],
+        ["uxv", "hypoxylon"],
+        ["opv", "cosmic_neutronium"]
+        ];
+
+    autoChargerWires.forEach(([tier, material]) => {
+        sog.replaceInput(
+            { id: `gtmutils:shaped/${tier}_auto_charger_4x` },
+            "gtceu:lead_quadruple_wire",
+            `gtceu:${material}_quadruple_wire`
+        );
+    });
+
+
+    // Diode UIV+
+
+    const diodeTiers = [
+        "uiv",
+        "uxv",
+        "opv"
+    ];
+
+    diodeTiers.forEach(tier => {
+        sog.replaceInput(
+            { id: `gtceu:shaped/${tier}_diode` },
+            "gtceu:advanced_smd_diode",
+            "kubejs:complex_smd_diode"
+            );
+        });
+
+
+    // UEV Singleblocks - Kaemite, Draconium, Resonant Essence
+
+    const UEVSingleBlockInputReplacement = { id: /^gtceu:shaped\/uev_.*/ };
+    [
+        ["gtceu:tin_single_wire", "gtceu:draconium_single_wire"],
+        ["gtceu:gold_single_wire", "gtceu:resonant_essence_single_wire"],
+        ["gtceu:copper_double_wire", "gtceu:kaemite_double_wire"],
+        ["gtceu:copper_quadruple_wire", "gtceu:resonant_essence_quadruple_wire"],
+        ["gtceu:lead_quadruple_wire", "gtceu:kaemite_quadruple_wire"],
+        ["gtceu:lead_octal_wire", "gtceu:resonant_essence_octal_wire"],
+        ["gtceu:lead_hex_wire", "gtceu:resonant_essence_hex_wire"],
+        ["gtceu:red_alloy_single_cable", "gtceu:draconium_single_cable"],
+        ["gtceu:red_alloy_quadruple_cable", "gtceu:draconium_quadruple_cable"],
+        ["#forge:glass", "kubejs:atomic_alloy_plated_glass"],
+        ["#ad_astra:iron_rods", "gtceu:kaemite_rod"],
+        ["#forge:plates/iron", "gtceu:kaemite_plate"],
+        ["gtceu:bronze_normal_fluid_pipe", "gtceu:europium_normal_fluid_pipe"],
+        ["gtceu:tin_rotor", "gtceu:resonant_essence_rotor"]
+    ].forEach(([from, to]) => {
+        sog.replaceInput(UEVSingleBlockInputReplacement, from, to);
+    });
+
+    // UIV Singleblocks - Awakened Draconium, Chaos
+
+    const UIVSingleBlockInputReplacement = { id: /^gtceu:shaped\/uiv_.*/ };
+    [
+        ["gtceu:tin_single_wire", "gtceu:awakened_draconium_single_wire"],
+        ["gtceu:gold_single_wire", "gtceu:chaos_single_wire"],
+        ["gtceu:copper_double_wire", "gtceu:chaos_double_wire"],
+        ["gtceu:copper_quadruple_wire", "gtceu:chaos_quadruple_wire"],
+        ["gtceu:lead_quadruple_wire", "gtceu:awakened_draconium_quadruple_wire"],
+        ["gtceu:lead_octal_wire", "gtceu:chaos_octal_wire"],
+        ["gtceu:lead_hex_wire", "gtceu:chaos_hex_wire"],
+        ["gtceu:red_alloy_single_cable", "gtceu:awakened_draconium_single_cable"],
+        ["gtceu:red_alloy_quadruple_cable", "gtceu:awakened_draconium_quadruple_cable"],
+        ["#forge:glass", "kubejs:fusion_glass_mk2"],
+        ["#ad_astra:iron_rods", "gtceu:awakened_draconium_rod"],
+        ["#forge:plates/iron", "gtceu:awakened_draconium_plate"],
+        ["gtceu:bronze_normal_fluid_pipe", "gtceu:europium_normal_fluid_pipe"],
+        ["gtceu:tin_rotor", "gtceu:awakened_draconium_rotor"]
+    ].forEach(([from, to]) => {
+        sog.replaceInput(UIVSingleBlockInputReplacement, from, to);
+    });
+
+    // UXV Singleblocks - Hypoxylon, Cosmic Duty Alloy
+
+    const UXVSingleBlockInputReplacement = { id: /^gtceu:shaped\/uxv_.*/ };
+    [
+        ["gtceu:tin_single_wire", "gtceu:hypoxylon_single_wire"],
+        ["gtceu:gold_single_wire", "gtceu:heavy_duty_alloy_t4_single_wire"],
+        ["gtceu:copper_double_wire", "gtceu:chaos_double_wire"],
+        ["gtceu:copper_quadruple_wire", "gtceu:chaos_quadruple_wire"],
+        ["gtceu:lead_quadruple_wire", "gtceu:hypoxylon_quadruple_wire"],
+        ["gtceu:lead_octal_wire", "gtceu:hypoxylon_octal_wire"],
+        ["gtceu:lead_hex_wire", "gtceu:hypoxylon_hex_wire"],
+        ["gtceu:red_alloy_single_cable", "gtceu:awakened_draconium_single_cable"],
+        ["gtceu:red_alloy_quadruple_cable", "gtceu:awakened_draconium_quadruple_cable"],
+        ["#forge:glass", "kubejs:fusion_glass_mk2"],
+        ["#ad_astra:iron_rods", "gtceu:hypoxylon_rod"],
+        ["#forge:plates/iron", "gtceu:hypoxylon_plate"],
+        ["gtceu:bronze_normal_fluid_pipe", "gtceu:europium_normal_fluid_pipe"],
+        ["gtceu:tin_rotor", "gtceu:heavy_duty_alloy_t4_rotor"]
+    ].forEach(([from, to]) => {
+        sog.replaceInput(UXVSingleBlockInputReplacement, from, to);
+    });
+
+    // OpV Singleblocks - Cosmic Neutronium
+
+    const OpVSingleBlockInputReplacement = { id: /^gtceu:shaped\/opv_.*/ };
+    [
+        ["gtceu:tin_single_wire", "gtceu:cosmic_neutronium_single_wire"],
+        ["gtceu:gold_single_wire", "gtceu:hypoxylon_single_wire"],
+        ["gtceu:copper_double_wire", "gtceu:chaos_double_wire"],
+        ["gtceu:copper_quadruple_wire", "gtceu:chaos_quadruple_wire"],
+        ["gtceu:lead_quadruple_wire", "gtceu:cosmic_neutronium_quadruple_wire"],
+        ["gtceu:lead_octal_wire", "gtceu:cosmic_neutronium_octal_wire"],
+        ["gtceu:lead_hex_wire", "gtceu:cosmic_neutronium_hex_wire"],
+        ["gtceu:red_alloy_single_cable", "gtceu:awakened_draconium_single_cable"],
+        ["gtceu:red_alloy_quadruple_cable", "gtceu:awakened_draconium_quadruple_cable"],
+        ["#forge:glass", "kubejs:fusion_glass_mk2"],
+        ["#ad_astra:iron_rods", "gtceu:cosmic_neutronium_rod"],
+        ["#forge:plates/iron", "gtceu:cosmic_neutronium_plate"],
+        ["gtceu:bronze_normal_fluid_pipe", "gtceu:europium_normal_fluid_pipe"],
+        ["gtceu:tin_rotor", "gtceu:cosmic_neutronium_rotor"]
+    ].forEach(([from, to]) => {
+        sog.replaceInput(OpVSingleBlockInputReplacement, from, to);
+    });
+
+
+    // Const Stuff
+
+    const gems = ["lapis", "sodalite", "lazurite"]
+        gems.forEach(gem => {
+            sog.recipes.gtceu.compressor(`${gem}_plate`)
+                .itemInputs(
+                    `gtceu:${gem}_dust`)
+                .itemOutputs(
+                    `gtceu:${gem}_plate`)
+                .duration(20 * 15)
+                .EUt(2)
+        })
+
+    const tiers = ["ulv", "lv", "mv", "hv", "ev", "iv", "luv", "zpm", "uv", "uhv", "uev", "uiv", "uxv", "opv"]
+        tiers.forEach((level) => {
+            sog.recipes.gtceu.forming_press("kubejs:" + level + "_universal_circuit")
+            .itemInputs(
+                "#gtceu:circuits/" + level)
+            .itemOutputs(
+                "kubejs:" + level + "_universal_circuit")
+            .EUt(32)
+            .duration(5)
+        })
+
+    const ebfHeavyAlloyRecipe = (tier, fluidInput, temperature, voltage, durationInSeconds) => {
+        const GAS_BOOST = 0.67
+        const idBase = `heavy_duty_alloy_t${tier}`
+
+        sog.recipes.gtceu.electric_blast_furnace(`blast_${idBase}`)
+            .itemInputs(
+                `gtceu:${idBase}_dust`)
+            .itemOutputs(
+                `gtceu:${idBase}_ingot`)
+            .blastFurnaceTemp(temperature)
+            .duration(20 * durationInSeconds)
+            .circuit(1)
+            .EUt(GTValues.VA[GTValues[voltage]])
+
+        sog.recipes.gtceu.electric_blast_furnace(`blast_${idBase}_gas`)
+            .itemInputs(
+                `gtceu:${idBase}_dust`)
+            .inputFluids(fluidInput)
+            .itemOutputs(
+                `gtceu:${idBase}_ingot`)
+            .blastFurnaceTemp(temperature)
+            .duration(20 * durationInSeconds * GAS_BOOST)
+            .circuit(2)
+            .EUt(GTValues.VA[GTValues[voltage]])
+    }
+
+    ebfHeavyAlloyRecipe(1, "gtceu:nitrogen 1000", 3500, "HV", 45)
+    ebfHeavyAlloyRecipe(2, "gtceu:argon 50", 5100, "LuV", 60)
+    ebfHeavyAlloyRecipe(3, "gtceu:krypton 10", 9600, "UHV", 65)
+
+
+    // Machine Recipes
+
+    sog.recipes.gtceu.compressor("diamondcompressing")
         .itemInputs(
-            '4x minecraft:coal_block'
-        )
+            "4x minecraft:coal_block")
         .itemOutputs(
-            'gtceu:tiny_diamond_dust'
-        )
+            "gtceu:tiny_diamond_dust")
         .duration(100)
         .EUt(2)
-    
-    sog.recipes.gtceu.forge_hammer('diamondhammah')
+
+    sog.recipes.gtceu.forge_hammer("diamondhammah")
         .itemInputs(
-            '4x gtceu:tiny_diamond_dust'
-        )
+            "4x gtceu:tiny_diamond_dust")
         .itemOutputs(
-            'minecraft:diamond'
-        )
+            "minecraft:diamond")
         .duration(600)
         .EUt(2)
 
-    sog.recipes.gtceu.macerator('gypsummacerator')
+    sog.recipes.gtceu.macerator("gypsummacerator")
         .itemInputs(
-            '4x exdeorum:dust'
-        )
+            "4x exdeorum:dust")
         .itemOutputs(
-            'gtceu:gypsum_dust'
-        )
+            "gtceu:gypsum_dust")
         .duration(15)
         .EUt(2)
 
-    sog.shaped('gtceu:firebricks', [// arg 1: output
-            'ABA', 
-            'BCB', // arg 2: the shape (array of strings)
-            'ABA'  
-          ], {
-            A: 'gtceu:firebrick', 
-            B: 'gtceu:gypsum_dust',  //arg 3: the mapping object
-            C: 'gtceu:concrete_bucket'
-          }
-          
-        )
-
-    sog.shaped('gtceu:lp_steam_alloy_smelter', [// arg 1: output
-            'ABA', 
-            'CDC', // arg 2: the shape (array of strings)
-            'AAA'  
-          ], {
-            A: 'gtceu:bronze_small_fluid_pipe', 
-            B: 'minecraft:diamond',  //arg 3: the mapping object
-            C: 'minecraft:furnace',
-            D: 'gtceu:bronze_brick_casing'
-          }
-          
-        )
-
-    sog.shaped('watersources:water_source_tier_1', [// arg 1: output
-            'ABA', 
-            'C C', // arg 2: the shape (array of strings)
-            'ABA'  
-          ], {
-            A: 'gtceu:firebrick', 
-            B: 'minecraft:glass',  //arg 3: the mapping object
-            C: 'minecraft:water_bucket'
-          }
-          
-        )
-    
-    sog.recipes.gtceu.coke_oven('sulfur')
-        .itemInputs('16x gtceu:stone_dust')
-        .itemOutputs('16x gtceu:sulfur_dust')
-        .outputFluids('exdeorum:witch_water 16000')
+    sog.recipes.gtceu.coke_oven("sulfur")
+        .itemInputs(
+            "16x gtceu:stone_dust")
+        .itemOutputs(
+            "16x gtceu:sulfur_dust")
+        .outputFluids(
+            "exdeorum:witch_water 16000")
         .duration(40)
-    sog.recipes.gtceu.coke_oven('graphite')
-        .itemInputs('64x gtceu:raw_coal')
-        .itemOutputs('8x gtceu:graphite_dust')
-        .outputFluids('gtceu:creosote 8000')
+
+    sog.recipes.gtceu.coke_oven("graphite")
+        .itemInputs(
+            "64x gtceu:raw_coal")
+        .itemOutputs(
+            "8x gtceu:graphite_dust")
+        .outputFluids(
+            "gtceu:creosote 8000")
         .duration(40)
-    sog.recipes.gtceu.pyrolyse_oven('sulfur')
-        .itemInputs('16x gtceu:stone_dust')
-        .itemOutputs('16x gtceu:sulfur_dust')
+
+    sog.recipes.gtceu.pyrolyse_oven("sulfur")
+        .itemInputs(
+            "16x gtceu:stone_dust")
+        .itemOutputs(
+            "16x gtceu:sulfur_dust")
         .duration(20 * 12)
         .EUt(96)
-    sog.recipes.gtceu.arc_furnace('lead')
-        .itemInputs('gtceu:raw_tin')
-        .inputFluids('gtceu:oxygen 63')
-        .itemOutputs('gtceu:raw_lead')
+
+    sog.recipes.gtceu.arc_furnace("lead")
+        .itemInputs(
+            "gtceu:raw_tin")
+        .inputFluids(
+            "gtceu:oxygen 63")
+        .itemOutputs(
+            "gtceu:raw_lead")
         .duration(5)
         .EUt(4)
-    sog.recipes.gtceu.arc_furnace('diamond')
-        .itemInputs('gtceu:raw_coal')
-        .inputFluids('gtceu:oxygen 63')
-        .itemOutputs('gtceu:raw_diamond')
+
+    sog.recipes.gtceu.arc_furnace("diamond")
+        .itemInputs(
+            "gtceu:raw_coal")
+        .inputFluids(
+            "gtceu:oxygen 63")
+        .itemOutputs(
+            "gtceu:raw_diamond")
         .duration(5)
         .EUt(4)
-    sog.recipes.gtceu.arc_furnace('silver')
-        .itemInputs('minecraft:raw_iron')
-        .inputFluids('gtceu:oxygen 63')
-        .itemOutputs('gtceu:raw_silver')
+
+    sog.recipes.gtceu.arc_furnace("silver")
+        .itemInputs(
+            "minecraft:raw_iron")
+        .inputFluids(
+            "gtceu:oxygen 63")
+        .itemOutputs(
+            "gtceu:raw_silver")
         .duration(5)
         .EUt(4)
-    sog.recipes.gtceu.arc_furnace('zinc')
-        .itemInputs('minecraft:raw_gold')
-        .inputFluids('gtceu:oxygen 63')
-        .itemOutputs('gtceu:raw_sphalerite')
+
+    sog.recipes.gtceu.arc_furnace("zinc")
+        .itemInputs(
+            "minecraft:raw_gold")
+        .inputFluids(
+            "gtceu:oxygen 63")
+        .itemOutputs(
+            "gtceu:raw_sphalerite")
         .duration(5)
         .EUt(4)
-    sog.recipes.gtceu.arc_furnace('lapis')
-        .itemInputs('gtceu:raw_diamond')
-        .inputFluids('gtceu:oxygen 63')
-        .itemOutputs('gtceu:raw_lapis')
+
+    sog.recipes.gtceu.arc_furnace("lapis")
+        .itemInputs(
+            "gtceu:raw_diamond")
+        .inputFluids(
+            "gtceu:oxygen 63")
+        .itemOutputs(
+            "gtceu:raw_lapis")
         .duration(5)
         .EUt(4)
-    sog.shaped('ironfurnaces:iron_furnace', [// arg 1: output
-            'AAA', 
-            'CBD', // arg 2: the shape (array of strings)
-            'AAA'  
-          ], {
-            A: 'gtceu:iron_plate', 
-            C: '#forge:tools/hammers',  //arg 3: the mapping object
-            B: 'ironfurnaces:copper_furnace',
-            D: '#forge:tools/wrenches'
-          }
-          
-        )
-    sog.shaped('ironfurnaces:gold_furnace', [// arg 1: output
-            'ABA', 
-            'BCB', // arg 2: the shape (array of strings)
-            'ABA'  
-          ], {
-            A: 'minecraft:glass', 
-            C: 'ironfurnaces:iron_furnace',  //arg 3: the mapping object
-            B: 'minecraft:gold_block'
-          }
-          
-        )
-    sog.recipes.gtceu.assembler('diamond_furnace')
-        .itemInputs('4x minecraft:diamond_block', 'ironfurnaces:gold_furnace')
-        .itemOutputs('ironfurnaces:diamond_furnace')
+
+
+    sog.recipes.gtceu.assembler("diamond_furnace")
+        .itemInputs(
+            "4x minecraft:diamond_block",
+            "ironfurnaces:gold_furnace")
+        .itemOutputs(
+            "ironfurnaces:diamond_furnace")
         .duration(100)
         .EUt(8)
-    sog.recipes.gtceu.assembler('emerald_furnace')
-        .itemInputs('4x minecraft:emerald_block', 'ironfurnaces:diamond_furnace')
-        .itemOutputs('ironfurnaces:emerald_furnace')
+
+    sog.recipes.gtceu.assembler("emerald_furnace")
+        .itemInputs(
+            "4x minecraft:emerald_block",
+            "ironfurnaces:diamond_furnace")
+        .itemOutputs(
+            "ironfurnaces:emerald_furnace")
         .duration(100)
         .EUt(128)
-    sog.recipes.gtceu.arc_furnace('quartz')
-        .itemInputs('gtceu:raw_silver')
-        .inputFluids('gtceu:oxygen 63')
-        .itemOutputs('gtceu:raw_nether_quartz')
+
+    sog.recipes.gtceu.arc_furnace("quartz")
+        .itemInputs(
+            "gtceu:raw_silver")
+        .inputFluids(
+            "gtceu:oxygen 63")
+        .itemOutputs(
+            "gtceu:raw_nether_quartz")
         .duration(5)
         .EUt(4)
-    sog.recipes.gtceu.arc_furnace('quartzite')
-        .itemInputs('gtceu:raw_nether_quartz')
-        .inputFluids('gtceu:nitrogen 63')
-        .itemOutputs('gtceu:raw_quartzite')
+
+    sog.recipes.gtceu.arc_furnace("quartzite")
+        .itemInputs(
+            "gtceu:raw_nether_quartz")
+        .inputFluids(
+            "gtceu:nitrogen 63")
+        .itemOutputs(
+            "gtceu:raw_quartzite")
         .duration(5)
         .EUt(4)
-    sog.recipes.gtceu.arc_furnace('nickel')
-        .itemInputs('minecraft:raw_copper')
-        .inputFluids('gtceu:nitrogen 63')
-        .itemOutputs('gtceu:raw_nickel')
+
+    sog.recipes.gtceu.arc_furnace("nickel")
+        .itemInputs(
+            "minecraft:raw_copper")
+        .inputFluids(
+            "gtceu:nitrogen 63")
+        .itemOutputs(
+            "gtceu:raw_nickel")
         .duration(5)
         .EUt(4)
-    sog.recipes.gtceu.arc_furnace('sapph')
-        .itemInputs('gtceu:raw_lapis')
-        .inputFluids('gtceu:nitrogen 63')
-        .itemOutputs('gtceu:sapphire_gem')
+
+    sog.recipes.gtceu.arc_furnace("sapph")
+        .itemInputs(
+            "gtceu:raw_lapis")
+        .inputFluids(
+            "gtceu:nitrogen 63")
+        .itemOutputs(
+            "gtceu:sapphire_gem")
         .duration(5)
         .EUt(4)
-    sog.recipes.gtceu.centrifuge('cobaltite')
-        .itemInputs('8x gtceu:raw_nickel')
-        .itemOutputs('2x gtceu:cobaltite_dust')
+
+    sog.recipes.gtceu.centrifuge("cobaltite")
+        .itemInputs(
+            "8x gtceu:raw_nickel")
+        .itemOutputs(
+            "2x gtceu:cobaltite_dust")
         .duration(100)
         .EUt(32)
-    sog.recipes.gtceu.centrifuge('gallium')
-        .itemInputs('8x gtceu:raw_sphalerite')
-        .itemOutputs('2x gtceu:gallium_dust')
+
+    sog.recipes.gtceu.centrifuge("gallium")
+        .itemInputs(
+            "8x gtceu:raw_sphalerite")
+        .itemOutputs(
+            "2x gtceu:gallium_dust")
         .duration(100)
         .EUt(32)
-    sog.recipes.gtceu.alloy_smelter('soularium')
-        .itemInputs('8x gtceu:brass_ingot', '8x minecraft:soul_sand')
-        .itemOutputs('4x enderio:soularium_ingot')
+
+    sog.recipes.gtceu.alloy_smelter("soularium")
+        .itemInputs(
+            "8x gtceu:brass_ingot",
+            "8x minecraft:soul_sand")
+        .itemOutputs(
+            "4x enderio:soularium_ingot")
         .duration(100)
         .EUt(8)
-    sog.recipes.gtceu.assembler('predictionmatrix')
-        .itemInputs('8x gtceu:aluminium_dust', '8x gtceu:gallium_dust', '32x minecraft:glass_pane')
-        .itemOutputs('8x hostilenetworks:prediction_matrix')
+
+    sog.recipes.gtceu.assembler("predictionmatrix")
+        .itemInputs(
+            "8x gtceu:aluminium_dust",
+            "8x gtceu:gallium_dust",
+            "32x minecraft:glass_pane")
+        .itemOutputs(
+            "8x hostilenetworks:prediction_matrix")
         .duration(20)
         .EUt(32)
-    sog.recipes.gtceu.assembler('simchamber')
-        .itemInputs('4x gtceu:steel_plate', '2x gtceu:cobaltite_dust', '3x gtceu:phenolic_printed_circuit_board', '#gtceu:circuits/lv')
-        .itemOutputs('hostilenetworks:sim_chamber')
+
+    sog.recipes.gtceu.assembler("simchamber")
+        .itemInputs(
+            "4x gtceu:steel_plate",
+            "2x gtceu:cobaltite_dust",
+            "3x gtceu:phenolic_printed_circuit_board",
+            "#gtceu:circuits/lv")
+        .itemOutputs(
+            "hostilenetworks:sim_chamber")
         .duration(100)
         .EUt(32)
-    sog.recipes.gtceu.assembler('simchamber_2')
-        .itemInputs('4x gtceu:steel_plate', '2x gtceu:cobaltite_dust', '2x gtceu:plastic_printed_circuit_board', '#gtceu:circuits/lv')
-        .itemOutputs('hostilenetworks:sim_chamber')
+
+    sog.recipes.gtceu.assembler("simchamber_2")
+        .itemInputs(
+            "4x gtceu:steel_plate",
+            "2x gtceu:cobaltite_dust",
+            "2x gtceu:plastic_printed_circuit_board",
+            "#gtceu:circuits/lv")
+        .itemOutputs(
+            "hostilenetworks:sim_chamber")
         .duration(100)
         .EUt(32)
-    sog.recipes.gtceu.assembler('lootchamber')
-        .itemInputs('4x gtceu:steel_plate', 'gtceu:gallium_arsenide_dust', '2x #gtceu:diodes', '3x #gtceu:circuits/lv')
-        .itemOutputs('hostilenetworks:loot_fabricator')
+
+    sog.recipes.gtceu.assembler("lootchamber")
+        .itemInputs(
+            "4x gtceu:steel_plate",
+            "gtceu:gallium_arsenide_dust",
+            "2x #gtceu:diodes",
+            "3x #gtceu:circuits/lv")
+        .itemOutputs(
+            "hostilenetworks:loot_fabricator")
         .duration(100)
         .EUt(32)
-    sog.recipes.gtceu.assembler('solidsteelmachinecasing')
-        .itemInputs('8x gtceu:steel_plate')
-        .itemOutputs('gtceu:steel_machine_casing')
+
+    sog.recipes.gtceu.assembler("solidsteelmachinecasing")
+        .itemInputs(
+            "8x gtceu:steel_plate")
+        .itemOutputs(
+            "gtceu:steel_machine_casing")
         .duration(100)
         .EUt(32)
         .circuit(9)
-    sog.recipes.gtceu.assembler('bronzemachinecasing')
-        .itemInputs('8x gtceu:bronze_plate')
-        .itemOutputs('gtceu:bronze_machine_casing')
+
+    sog.recipes.gtceu.assembler("bronzemachinecasing")
+        .itemInputs(
+            "8x gtceu:bronze_plate")
+        .itemOutputs(
+            "gtceu:bronze_machine_casing")
         .duration(100)
         .EUt(32)
         .circuit(8)
-    sog.recipes.gtceu.assembler('hss_e_casing')
-        .itemInputs('8x gtceu:hsse_plate')
-        .itemOutputs('gtceu:sturdy_machine_casing')
+
+    sog.recipes.gtceu.assembler("hss_e_casing")
+        .itemInputs(
+            "8x gtceu:hsse_plate")
+        .itemOutputs(
+            "gtceu:sturdy_machine_casing")
         .duration(100)
         .EUt(32)
         .circuit(6)
-        sog.recipes.gtceu.assembler('eternity_casing')
-        .itemInputs('8x gtceu:eternity_plate', 'gtceu:eternity_frame')
-        .itemOutputs('kubejs:eternity_casing')
+
+    sog.recipes.gtceu.assembler("eternity_casing")
+        .itemInputs(
+            "8x gtceu:eternity_plate",
+            "gtceu:eternity_frame")
+        .itemOutputs(
+            "kubejs:eternity_casing")
         .duration(170000)
         .EUt(32)
         .circuit(6)
-    sog.recipes.gtceu.assembler('uivmachinecasing')
-        .itemInputs('8x gtceu:draconium_plate', '1x kubejs:draconium_heavy_plating')
-        .itemOutputs('gtceu:uiv_machine_casing')
+
+    sog.recipes.gtceu.assembler("uivmachinecasing")
+        .itemInputs(
+            "8x gtceu:draconium_plate",
+            "1x kubejs:draconium_heavy_plating")
+        .itemOutputs(
+            "gtceu:uiv_machine_casing")
         .EUt(32)
         .duration(100)
         .circuit(8)
-        sog.recipes.gtceu.assembler('uxvmachinecasing')
-        .itemInputs('8x gtceu:chaos_plate', 'kubejs:awakened_draconium_heavy_plating')
-        .itemOutputs('gtceu:uxv_machine_casing')
+
+    sog.recipes.gtceu.assembler("uxvmachinecasing")
+        .itemInputs(
+            "8x gtceu:chaos_plate",
+            "kubejs:awakened_draconium_heavy_plating")
+        .itemOutputs(
+            "gtceu:uxv_machine_casing")
         .EUt(32)
         .duration(100)
         .circuit(8)
-        sog.recipes.gtceu.assembler('opvmachinecasing')
-        .itemInputs('8x gtceu:chrono_infinity_plate', 'kubejs:infinity_heavy_plating')
-        .itemOutputs('gtceu:opv_machine_casing')
+
+    sog.recipes.gtceu.assembler("opvmachinecasing")
+        .itemInputs(
+            "8x gtceu:chrono_infinity_plate",
+            "kubejs:infinity_heavy_plating")
+        .itemOutputs(
+            "gtceu:opv_machine_casing")
         .EUt(32)
         .duration(100)
         .circuit(8)
-        sog.recipes.gtceu.assembler('dimensional_pumping_module')
-        .itemInputs('8x kubejs:space_time_heavy_plating', 'gtceu:uiv_fluid_regulator')
-        .itemOutputs('kubejs:dimensional_pump_module')
+
+    sog.recipes.gtceu.assembler("dimensional_pumping_module")
+        .itemInputs(
+            "8x kubejs:space_time_heavy_plating",
+            "gtceu:uiv_fluid_regulator")
+        .itemOutputs(
+            "kubejs:dimensional_pump_module")
         .duration(100)
         .EUt(32)
-        sog.recipes.gtceu.assembler('trascendental_space_time_casing')
-        .itemInputs('16x kubejs:space_time_heavy_plating')
-        .itemOutputs('kubejs:trascendental_space_time_casing')
+
+    sog.recipes.gtceu.assembler("trascendental_space_time_casing")
+        .itemInputs(
+            "16x kubejs:space_time_heavy_plating")
+        .itemOutputs(
+            "kubejs:trascendental_space_time_casing")
         .EUt(32)
         .duration(100)
         .circuit(6)
-        sog.recipes.gtceu.assembler('high_power_casing_plant')
-        .itemInputs('8x gtceu:osmiridium_plate', 'gtceu:secure_maceration_casing')
-        .itemOutputs('kubejs:high_power_casing')
+
+    sog.recipes.gtceu.assembler("high_power_casing_plant")
+        .itemInputs(
+            "8x gtceu:osmiridium_plate",
+            "gtceu:secure_maceration_casing")
+        .itemOutputs(
+            "kubejs:high_power_casing")
         .EUt((GTValues.VA[GTValues.IV]))
         .duration(100)
         .circuit(8)
-        sog.recipes.gtceu.assembler('high_power_crushing_wheels')
-        .itemInputs('8x gtceu:rhodium_plated_palladium_plate', 'kubejs:high_power_casing', 'gtceu:iv_electric_motor')
-        .itemOutputs('kubejs:high_power_crushing_wheels')
+
+    sog.recipes.gtceu.assembler("high_power_crushing_wheels")
+        .itemInputs(
+            "8x gtceu:rhodium_plated_palladium_plate",
+            "kubejs:high_power_casing",
+            "gtceu:iv_electric_motor")
+        .itemOutputs(
+            "kubejs:high_power_crushing_wheels")
         .EUt((GTValues.VA[GTValues.IV]))
         .duration(100)
         .circuit(8)
-        sog.recipes.gtceu.assembler('semi_stable_casing')
-        .itemInputs('8x gtceu:pure_cosmic_matter_plate', '8x #gtceu:circuits/uev', '2x #gtceu:circuits/uiv')
-        .itemOutputs('kubejs:semi_stable_casing')
+
+    sog.recipes.gtceu.assembler("semi_stable_casing")
+        .itemInputs(
+            "8x gtceu:pure_cosmic_matter_plate",
+            "8x #gtceu:circuits/uev",
+            "2x #gtceu:circuits/uiv")
+        .itemOutputs(
+            "kubejs:semi_stable_casing")
         .EUt((GTValues.VA[GTValues.UIV]))
         .duration(100)
         .circuit(8)
-        sog.recipes.gtceu.assembler('cryogenic_casing')
-        .itemInputs('8x gtceu:cosmic_iridium_plate', '8x #gtceu:circuits/uv', '2x #gtceu:circuits/uhv')
-        .itemOutputs('kubejs:cryogenic_casing')
+
+    sog.recipes.gtceu.assembler("cryogenic_casing")
+        .itemInputs(
+            "8x gtceu:cosmic_iridium_plate",
+            "8x #gtceu:circuits/uv",
+            "2x #gtceu:circuits/uhv")
+        .itemOutputs(
+            "kubejs:cryogenic_casing")
         .EUt((GTValues.VA[GTValues.UEV]))
         .duration(100)
         .circuit(8)
-        sog.recipes.gtceu.assembler('kevlar_casing')
-        .itemInputs('8x gtceu:kevlar_plate', '8x #gtceu:circuits/uhv', '2x #gtceu:circuits/uev')
-        .itemOutputs('kubejs:kevlar_casing')
+
+    sog.recipes.gtceu.assembler("kevlar_casing")
+        .itemInputs(
+            "8x gtceu:kevlar_plate",
+            "8x #gtceu:circuits/uhv",
+            "2x #gtceu:circuits/uev")
+        .itemOutputs(
+            "kubejs:kevlar_casing")
         .EUt((GTValues.VA[GTValues.UEV]))
         .duration(100)
         .circuit(8)
-        sog.recipes.gtceu.assembler('intake_kevlar_hatch')
-        .itemInputs('8x gtceu:kevlar_plate', 'kubejs:ultimate_engine_intake_casing', 'gtceu:uiv_electric_motor')
-        .itemOutputs('kubejs:advanced_air_intake_hatch')
+
+    sog.recipes.gtceu.assembler("intake_kevlar_hatch")
+        .itemInputs(
+            "8x gtceu:kevlar_plate",
+            "kubejs:ultimate_engine_intake_casing",
+            "gtceu:uiv_electric_motor")
+        .itemOutputs(
+            "kubejs:advanced_air_intake_hatch")
         .EUt((GTValues.VA[GTValues.UEV]))
         .duration(100)
         .circuit(8)
-    sog.recipes.gtceu.alloy_smelter('soulsand')
-        .itemInputs('8x minecraft:ink_sac', '16x minecraft:sand')
-        .itemOutputs('4x minecraft:soul_sand')
+
+    sog.recipes.gtceu.alloy_smelter("soulsand")
+        .itemInputs(
+            "8x minecraft:ink_sac",
+            "16x minecraft:sand")
+        .itemOutputs(
+            "4x minecraft:soul_sand")
         .duration(140)
         .EUt(32)
-    sog.recipes.gtceu.alloy_smelter('conduitbinder')
-        .itemInputs('8x enderio:conduit_binder_composite', '2x enderio:soularium_ingot')
-        .itemOutputs('12x enderio:conduit_binder')
+
+    sog.recipes.gtceu.alloy_smelter("conduitbinder")
+        .itemInputs(
+            "8x enderio:conduit_binder_composite",
+            "2x enderio:soularium_ingot")
+        .itemOutputs(
+            "12x enderio:conduit_binder")
         .duration(60)
         .EUt(32)
-    sog.recipes.gtceu.mixer('pulsatingiron')
-        .itemInputs('4x minecraft:iron_ingot', 'gtceu:aluminium_ingot')
-        .itemOutputs('3x enderio:pulsating_alloy_ingot')
+
+    sog.recipes.gtceu.mixer("pulsatingiron")
+        .itemInputs(
+            "4x minecraft:iron_ingot",
+            "gtceu:aluminium_ingot")
+        .itemOutputs(
+            "3x enderio:pulsating_alloy_ingot")
         .duration(100)
         .EUt(32)
-    sog.recipes.gtceu.mixer('redstonealloy')
-        .itemInputs('4x gtceu:red_alloy_ingot', 'gtceu:lead_ingot')
-        .itemOutputs('3x enderio:redstone_alloy_ingot')
+
+    sog.recipes.gtceu.mixer("redstonealloy")
+        .itemInputs(
+            "4x gtceu:red_alloy_ingot",
+            "gtceu:lead_ingot")
+        .itemOutputs(
+            "3x enderio:redstone_alloy_ingot")
         .duration(100)
         .EUt(32)
-    sog.recipes.gtceu.mixer('conductiveiron')
-        .itemInputs('4x minecraft:iron_ingot', '2x gtceu:annealed_copper_ingot', 'gtceu:red_alloy_ingot')
-        .itemOutputs('4x enderio:conductive_alloy_ingot')
+
+    sog.recipes.gtceu.mixer("conductiveiron")
+        .itemInputs(
+            "4x minecraft:iron_ingot",
+            "2x gtceu:annealed_copper_ingot",
+            "gtceu:red_alloy_ingot")
+        .itemOutputs(
+            "4x enderio:conductive_alloy_ingot")
         .duration(100)
         .EUt(32)
-    sog.shaped('gtceu:lv_mixer', [// arg 1: output
-            'ABA', 
-            'ACA', // arg 2: the shape (array of strings)
-            'DED'  
-          ], {
-            A: 'enderio:soularium_ingot', 
-            C: 'gtceu:lv_electric_motor',  //arg 3: the mapping object
-            B: 'gtceu:tin_rotor',
-            D: '#gtceu:circuits/lv',
-            E: 'gtceu:lv_machine_hull'
-          }
-        )
-    sog.recipes.gtceu.wiremill('simplecable')
-        .itemInputs('2x enderio:conductive_alloy_ingot')
-        .itemOutputs('4x storagenetwork:kabel')
+
+    sog.recipes.gtceu.wiremill("simplecable")
+        .itemInputs(
+            "2x enderio:conductive_alloy_ingot")
+        .itemOutputs(
+            "4x storagenetwork:kabel")
         .duration(20)
         .EUt(32)
-    sog.recipes.gtceu.assembler('master')
-        .itemInputs('ironchest:gold_chest', '4x #gtceu:circuits/lv', 'gtceu:lv_machine_hull')
-        .itemOutputs('storagenetwork:master')
+
+    sog.recipes.gtceu.assembler("master")
+        .itemInputs(
+            "ironchest:gold_chest",
+            "4x #gtceu:circuits/lv",
+            "gtceu:lv_machine_hull")
+        .itemOutputs(
+            "storagenetwork:master")
         .duration(1000)
         .EUt(32) 
-    sog.recipes.gtceu.assembler('request')
-        .itemInputs('8x minecraft:glass', 'gtceu:lv_machine_hull', '4x #gtceu:circuits/lv', 'avaritia:double_compressed_crafting_table')
-        .itemOutputs('storagenetwork:request')
+
+    sog.recipes.gtceu.assembler("request")
+        .itemInputs(
+            "8x minecraft:glass",
+            "gtceu:lv_machine_hull",
+            "4x #gtceu:circuits/lv",
+            "avaritia:double_compressed_crafting_table")
+        .itemOutputs(
+            "storagenetwork:request")
         .duration(1000)
         .EUt(32) 
-    sog.recipes.gtceu.assembler('upgradebase')
-          .itemInputs('16x minecraft:leather', '64x minecraft:string', 'minecraft:iron_block')
-          .itemOutputs('sophisticatedbackpacks:upgrade_base')
-          .duration(100)
-          .EUt(32) 
-    sog.recipes.gtceu.forge_hammer('dustex')
-          .itemInputs('minecraft:sand')
-          .itemOutputs('exdeorum:dust')
-          .duration(15)
-          .EUt(8)     
-    sog.recipes.gtceu.centrifuge('emerald')
-          .itemInputs('8x gtceu:raw_diamond')
-          .itemOutputs('2x gtceu:raw_emerald')
-          .duration(300)
-          .EUt(128) 
-    sog.recipes.gtceu.centrifuge('rubydust')
-          .itemInputs('gtceu:redstone_plate')
-          .itemOutputs('8x gtceu:ruby_gem')
-          .duration(80)
-          .EUt(128) 
-    sog.recipes.gtceu.centrifuge('vanadium')
-          .itemInputs('gtceu:wrought_iron_ingot')
-          .itemOutputs('2x gtceu:vanadium_dust')
-          .duration(80)
-          .EUt(128)
-    sog.shaped('gtceu:mv_mixer', [// arg 1: output
-            'ABA', 
-            'ACA', // arg 2: the shape (array of strings)
-            'DED'  
-          ], {
-            A: 'enderio:soularium_ingot', 
-            C: 'gtceu:mv_electric_motor',  //arg 3: the mapping object
-            B: 'gtceu:cobalt_brass_gear',
-            D: '#gtceu:circuits/mv',
-            E: 'gtceu:mv_machine_hull'
-          }
-        )
-    sog.recipes.gtceu.arc_furnace('clay')
-        .itemInputs('exdeorum:dust')
-        .inputFluids('minecraft:water 1000')
-        .itemOutputs('minecraft:clay')
-        .duration(60)
-        .EUt(128)
-    sog.recipes.gtceu.arc_furnace('watert2')
-        .itemInputs('watersources:water_source_tier_1')
-        .inputFluids('gtceu:distilled_water 5000')
-        .itemOutputs('watersources:water_source_tier_2')
-        .duration(800)
-        .EUt(128)
-    sog.recipes.gtceu.centrifuge('manganese')
-        .itemInputs('8x gtceu:raw_calcite')
-        .itemOutputs('2x gtceu:manganese_dust')
+
+    sog.recipes.gtceu.assembler("upgradebase")
+        .itemInputs(
+            "16x minecraft:leather",
+            "64x minecraft:string",
+            "minecraft:iron_block")
+        .itemOutputs(
+            "sophisticatedbackpacks:upgrade_base")
+        .duration(100)
+        .EUt(32) 
+
+    sog.recipes.gtceu.forge_hammer("dustex")
+        .itemInputs(
+            "minecraft:sand")
+        .itemOutputs(
+            "exdeorum:dust")
+        .duration(15)
+        .EUt(8)     
+
+    sog.recipes.gtceu.centrifuge("emerald")
+        .itemInputs(
+            "8x gtceu:raw_diamond")
+        .itemOutputs(
+            "2x gtceu:raw_emerald")
+        .duration(300)
+        .EUt(128) 
+
+    sog.recipes.gtceu.centrifuge("rubydust")
+        .itemInputs(
+            "gtceu:redstone_plate")
+        .itemOutputs(
+            "8x gtceu:ruby_gem")
+        .duration(80)
+        .EUt(128) 
+
+    sog.recipes.gtceu.centrifuge("vanadium")
+        .itemInputs(
+            "gtceu:wrought_iron_ingot")
+        .itemOutputs(
+            "2x gtceu:vanadium_dust")
         .duration(80)
         .EUt(128)
-    sog.shapeless('2x gtceu:rubber_planks', [ // arg 1: output
-            'gtceu:rubber_log'
-          ])
-    sog.recipes.gtceu.electrolyzer('phosphorus')
-        .itemInputs('64x minecraft:glowstone_dust')
-        .itemOutputs('8x gtceu:phosphorus_dust')
+
+    sog.recipes.gtceu.arc_furnace("clay")
+        .itemInputs(
+            "exdeorum:dust")
+        .inputFluids(
+            "minecraft:water 1000")
+        .itemOutputs(
+            "minecraft:clay")
+        .duration(60)
+        .EUt(128)
+
+    sog.recipes.gtceu.arc_furnace("watert2")
+        .itemInputs(
+            "watersources:water_source_tier_1")
+        .inputFluids(
+            "gtceu:distilled_water 5000")
+        .itemOutputs(
+            "watersources:water_source_tier_2")
+        .duration(800)
+        .EUt(128)
+
+    sog.recipes.gtceu.centrifuge("manganese")
+        .itemInputs(
+            "8x gtceu:raw_calcite")
+        .itemOutputs(
+            "2x gtceu:manganese_dust")
+        .duration(80)
+        .EUt(128)
+
+    sog.recipes.gtceu.electrolyzer("phosphorus")
+        .itemInputs(
+            "64x minecraft:glowstone_dust")
+        .itemOutputs(
+            "8x gtceu:phosphorus_dust")
         .duration(200)
         .EUt(512)
-    sog.recipes.gtceu.assembler('enderchest')
-        .itemInputs('gtceu:hv_super_chest', 'minecraft:ender_eye')
-        .inputFluids('gtceu:ender_air 5000')
-        .itemOutputs('enderchests:ender_chest')
+
+    sog.recipes.gtceu.assembler("enderchest")
+        .itemInputs(
+            "gtceu:hv_super_chest",
+            "minecraft:ender_eye")
+        .inputFluids(
+            "gtceu:ender_air 5000")
+        .itemOutputs(
+            "enderchests:ender_chest")
         .duration(400)
         .EUt(512)
-    sog.recipes.gtceu.assembler('endertank')
-        .itemInputs('gtceu:lv_super_tank', 'minecraft:ender_eye')
-        .inputFluids('gtceu:ender_air 5000')
-        .itemOutputs('endertanks:ender_tank')
+
+    sog.recipes.gtceu.assembler("endertank")
+        .itemInputs(
+            "gtceu:lv_super_tank",
+            "minecraft:ender_eye")
+        .inputFluids(
+            "gtceu:ender_air 5000")
+        .itemOutputs(
+            "endertanks:ender_tank")
         .duration(200)
         .EUt(512)
-    sog.recipes.gtceu.mixer('platinum')
-        .itemInputs('8x gtceu:silver_dust', '2x gtceu:ender_eye_block', 'enderio:pulsating_alloy_ingot')
-        .inputFluids('gtceu:ender_air 5000', 'gtceu:deuterium 1000')
-        .itemOutputs('2x gtceu:platinum_dust')
+
+    sog.recipes.gtceu.mixer("platinum")
+        .itemInputs(
+            "8x gtceu:silver_dust",
+            "2x gtceu:ender_eye_block",
+            "enderio:pulsating_alloy_ingot")
+        .inputFluids(
+            "gtceu:ender_air 5000",
+            "gtceu:deuterium 1000")
+        .itemOutputs(
+            "2x gtceu:platinum_dust")
         .duration(100)
         .EUt(512)
-    sog.recipes.gtceu.arc_furnace('potasio')
-        .itemInputs('gtceu:calcite_dust')
-        .inputFluids('gtceu:nitrogen_dioxide 63')
-        .itemOutputs('2x gtceu:potassium_dust')
+
+    sog.recipes.gtceu.arc_furnace("potasio")
+        .itemInputs(
+            "gtceu:calcite_dust")
+        .inputFluids(
+            "gtceu:nitrogen_dioxide 63")
+        .itemOutputs(
+            "2x gtceu:potassium_dust")
         .duration(15)
         .EUt(512)
-    sog.recipes.gtceu.centrifuge('salt')
-        .itemInputs('gtceu:potassium_dust')
-        .itemOutputs('8x gtceu:salt_dust')
+
+    sog.recipes.gtceu.centrifuge("salt")
+        .itemInputs(
+            "gtceu:potassium_dust")
+        .itemOutputs(
+            "8x gtceu:salt_dust")
         .duration(15)
         .EUt(512)
-    sog.shaped('ae2:controller', [// arg 1: output
-            'ABA', 
-            'BCB', // arg 2: the shape (array of strings)
-            'ADA'  
-          ], {
-            A: 'gtceu:platinum_ingot', 
-            C: 'gtceu:hv_machine_hull',  //arg 3: the mapping object
-            B: 'gtceu:lpic_chip',
-            D: '#gtceu:circuits/hv'
-          }
-        )
-    sog.shaped('bonsaitrees3:bonsaipot', [// arg 1: output
-        'AAA', 
-        'ABA', // arg 2: the shape (array of strings)
-        'AAA'  
-      ], {
-        A: 'gtceu:firebrick',
-        B: 'minecraft:dirt'
-      }
-    )
-    sog.recipes.gtceu.cutter('press')
-        .itemInputs('16x gtceu:certus_quartz_plate')
-        .inputFluids('gtceu:lubricant 1000')
-        .itemOutputs('ae2:name_press')
+
+    sog.recipes.gtceu.cutter("press")
+        .itemInputs(
+            "16x gtceu:certus_quartz_plate")
+        .inputFluids(
+            "gtceu:lubricant 1000")
+        .itemOutputs(
+            "ae2:name_press")
         .duration(2400)
         .EUt(512)
-    sog.recipes.gtceu.circuit_assembler('engiprocess')
-        .itemInputs('ae2:silicon', 'minecraft:redstone', 'minecraft:diamond')
-        .inputFluids('gtceu:lubricant 63')
-        .notConsumable('ae2:name_press')
-        .itemOutputs('ae2:engineering_processor')
+
+    sog.recipes.gtceu.circuit_assembler("engiprocess")
+        .itemInputs(
+            "ae2:silicon",
+            "minecraft:redstone",
+            "minecraft:diamond")
+        .inputFluids(
+            "gtceu:lubricant 63")
+        .notConsumable(
+            "ae2:name_press")
+        .itemOutputs(
+            "ae2:engineering_processor")
         .duration(40)
         .EUt(128)
-    sog.recipes.gtceu.circuit_assembler('calcprocess')
-        .itemInputs('ae2:silicon', 'minecraft:redstone', 'gtceu:certus_quartz_dust')
-        .inputFluids('gtceu:lubricant 63')
-        .notConsumable('ae2:name_press')
-        .itemOutputs('ae2:calculation_processor')
+
+    sog.recipes.gtceu.circuit_assembler("calcprocess")
+        .itemInputs(
+            "ae2:silicon",
+            "minecraft:redstone",
+            "gtceu:certus_quartz_dust")
+        .inputFluids(
+            "gtceu:lubricant 63")
+        .notConsumable(
+            "ae2:name_press")
+        .itemOutputs(
+            "ae2:calculation_processor")
         .duration(40)
         .EUt(128)
-    sog.recipes.gtceu.circuit_assembler('logicprocess')
-        .itemInputs('ae2:silicon', 'minecraft:redstone', 'minecraft:gold_ingot')
-        .inputFluids('gtceu:lubricant 63')
-        .notConsumable('ae2:name_press')
-        .itemOutputs('ae2:logic_processor')
+
+    sog.recipes.gtceu.circuit_assembler("logicprocess")
+        .itemInputs(
+            "ae2:silicon",
+            "minecraft:redstone",
+            "minecraft:gold_ingot")
+        .inputFluids(
+            "gtceu:lubricant 63")
+        .notConsumable(
+            "ae2:name_press")
+        .itemOutputs(
+            "ae2:logic_processor")
         .duration(40)
         .EUt(128)
-    sog.recipes.gtceu.mixer('fluix')
-        .itemInputs('gtceu:quartzite_gem', 'minecraft:redstone', 'gtceu:certus_quartz_dust')
-        .inputFluids('minecraft:water 1000')
-        .itemOutputs('3x ae2:fluix_crystal')
+
+    sog.recipes.gtceu.mixer("fluix")
+        .itemInputs(
+            "gtceu:quartzite_gem",
+            "minecraft:redstone",
+            "gtceu:certus_quartz_dust")
+        .inputFluids(
+            "minecraft:water 1000")
+        .itemOutputs(
+            "3x ae2:fluix_crystal")
         .duration(15)
         .EUt(512)
-    sog.recipes.gtceu.macerator('fluixdust')
-        .itemInputs('ae2:fluix_crystal')
-        .itemOutputs('ae2:fluix_dust')
+
+    sog.recipes.gtceu.macerator("fluixdust")
+        .itemInputs(
+            "ae2:fluix_crystal")
+        .itemOutputs(
+            "ae2:fluix_dust")
         .duration(15)
         .EUt(512)
-    sog.recipes.gtceu.alloy_smelter('quartzglass')
-        .itemInputs('5x gtceu:certus_quartz_dust', '4x #forge:glass')
-        .itemOutputs('4x ae2:quartz_glass')
+
+    sog.recipes.gtceu.alloy_smelter("quartzglass")
+        .itemInputs(
+            "5x gtceu:certus_quartz_dust",
+            "4x #forge:glass")
+        .itemOutputs(
+            "4x ae2:quartz_glass")
         .duration(200)
         .EUt(32)
-    sog.shaped('ae2:cell_component_1k', [// arg 1: output
-            'ABA', 
-            'BCB', // arg 2: the shape (array of strings)
-            'ABA'  
-          ], {
-            A: 'minecraft:redstone',
-            B: 'gtceu:certus_quartz_gem',
-            C: '#gtceu:circuits/lv'
-          }
-        )
-    sog.shaped('ae2:cell_component_4k', [// arg 1: output
-            'ABA', 
-            'BCB', // arg 2: the shape (array of strings)
-            'ABA'  
-          ], {
-            A: 'minecraft:redstone',
-            B: 'gtceu:certus_quartz_gem',
-            C: '#gtceu:circuits/mv'
-          }
-        )
-    sog.shaped('ae2:cell_component_16k', [// arg 1: output
-            'ABA', 
-            'BCB', // arg 2: the shape (array of strings)
-            'ABA'  
-          ], {
-            A: 'minecraft:redstone',
-            B: 'gtceu:certus_quartz_gem',
-            C: '#gtceu:circuits/hv'
-          }
-        )
-    sog.shaped('ae2:cell_component_64k', [// arg 1: output
-            'ABA', 
-            'BCB', // arg 2: the shape (array of strings)
-            'ABA'  
-          ], {
-            A: 'minecraft:redstone',
-            B: 'gtceu:certus_quartz_gem',
-            C: '#gtceu:circuits/ev'
-          }
-        )
-    sog.shaped('ae2:cell_component_256k', [// arg 1: output
-            'ABA', 
-            'BCB', // arg 2: the shape (array of strings)
-            'ABA'  
-          ], {
-            A: 'minecraft:redstone',
-            B: 'gtceu:certus_quartz_gem',
-            C: '#gtceu:circuits/iv'
-          }
-        )
-    sog.shaped('megacells:cell_component_1m', [
-        'ABA',
-        'CDC',
-        'ACA'
-    ], {
-        A: 'ae2:sky_dust',
-        B: 'megacells:accumulation_processor',
-        C: 'ae2:cell_component_256k',
-        D: '#gtceu:circuits/luv'
-      }
-    )
-    sog.shaped('megacells:cell_component_4m',[
-        'ABA',
-        'CDC',
-        'ACA'
-    ], {
-        A: '#forge:dusts/ender_pearl',
-        B: 'megacells:accumulation_processor',
-        C: 'megacells:cell_component_1m',
-        D: '#gtceu:circuits/zpm'
-      }
-    )
-    sog.shaped('megacells:cell_component_16m',[
-        'ABA',
-        'CDC',
-        'ACA'
-    ], {
-        A: '#forge:dusts/ender_pearl',
-        B: 'megacells:accumulation_processor',
-        C: 'megacells:cell_component_4m',
-        D: '#gtceu:circuits/uv'
-      }
-    )
-    sog.shaped('megacells:cell_component_64m',[
-        'ABA',
-        'CDC',
-        'ACA'
-    ], {
-        A: 'ae2:matter_ball',
-        B: 'megacells:accumulation_processor',
-        C: 'megacells:cell_component_16m',
-        D: '#gtceu:circuits/uhv'
-      }
-    )
-    sog.shaped('megacells:cell_component_256m',[
-        'ABA',
-        'CDC',
-        'ACA'
-    ], {
-        A: 'ae2:matter_ball',
-        B: 'megacells:accumulation_processor',
-        C: 'megacells:cell_component_64m',
-        D: '#gtceu:circuits/uev'
-      }
-    )
-    sog.shaped('ae2:drive', [// arg 1: output
-            'ABA', 
-            'C C', // arg 2: the shape (array of strings)
-            'ABA'  
-          ], {
-            A: 'gtceu:platinum_ingot',
-            B: '#gtceu:circuits/hv',
-            C: 'enderio:me_conduit'
-          }
-        )
-    sog.shaped('ad_astra:nasa_workbench', [// arg 1: output
-          'ABA', 
-          'CDC', // arg 2: the shape (array of strings)
-          'EFE'  
-        ], {
-          A: 'gtceu:steel_frame',
-          E: '#gtceu:circuits/ev',
-          B: 'gtceu:platinum_single_wire',
-          C: 'gtceu:double_steel_plate',
-          D: 'gtceu:kanthal_coil_block',
-          F: 'gtceu:steel_block'
-        }
-      )
 
-    sog.shaped('bigger_ae2:advanced_fluid_cell_housing', [
-            'ABA',
-            'B B',
-            'PPP'
-        ], {
-            A: '#gtceu:circuits/luv',
-            B: 'gtceu:certus_quartz_plate',
-            P: 'gtceu:rhodium_plated_palladium_plate'
-        }
-    )
-
-        sog.shaped('bigger_ae2:quantum_cell_component', [
-            'ADA',
-            'BCB',
-            'ABA'
-        ], {
-            A: 'gtceu:resonant_naquadah_plate',
-            B: 'ae2:cell_component_256k',
-            C: 'gtceu:duranium_plate',
-            D: '#gtceu:circuits/zpm'
-        }
-    )
-
-        sog.shaped('bigger_ae2:digital_singularity_cell_component', [
-            'ADA',
-            'BCB',
-            'ABA'
-        ], {
-            A: 'gtceu:cleaned_californium_plate',
-            B: 'bigger_ae2:quantum_cell_component',
-            C: 'gtceu:neutronium_plate',
-            D: '#gtceu:circuits/uv'
-        }
-    )
-
-            sog.shaped('expandedae:artificial_universe_fluid_cell', [
-            'ADA',
-            'BCB',
-            'ABA'
-        ], {
-            A: 'gtceu:resonant_essence_plate',
-            B: 'bigger_ae2:digital_singularity_cell_component',
-            D: '#gtceu:circuits/uev',
-            C: 'avaritia:eternal_singularity'
-        }
-    )
-            sog.shaped('expandedae:artificial_universe_item_cell', [
-            'ADA',
-            'BCB',
-            'ABA'
-        ], {
-            A: 'gtceu:cosmic_neutronium_plate',
-            B: 'bigger_ae2:digital_singularity_cell_component',
-            D: '#gtceu:circuits/uev',
-            C: 'avaritia:eternal_singularity'
-        }
-    )
-
-    ////// Machine Recipe //////
-
-    sog.shaped(
-        'gtceu:moonminer',
-        ['AWA', 'CSC', 'WCW'],
-        {
-            A: '#gtceu:circuits/ev',
-            W: 'ad_astra:desh_block',
-            C: '#gtceu:circuits/ev',
-            S: 'ad_astra:moon_globe'
-        }
-    ).id('gtceu:shaped/moonminer')
-  
-
-    sog.recipes.gtceu.distillery('fuelastra')
+    sog.recipes.gtceu.distillery("fuelastra")
         .circuit(5)
-        .inputFluids('gtceu:diesel 1000')
-        .outputFluids('ad_astra:fuel 250')
+        .inputFluids(
+            "gtceu:diesel 1000")
+        .outputFluids(
+            "ad_astra:fuel 250")
         .duration(2000)
         .EUt(24)
-    sog.recipes.gtceu.alloy_smelter('neodymium')
-        .itemInputs('8x gtceu:potin_dust', '4x gtceu:stainless_steel_dust')
-        .itemOutputs('4x gtceu:neodymium_dust')
+
+    sog.recipes.gtceu.alloy_smelter("neodymium")
+        .itemInputs(
+            "8x gtceu:potin_dust",
+            "4x gtceu:stainless_steel_dust")
+        .itemOutputs(
+            "4x gtceu:neodymium_dust")
         .duration(120)
         .EUt(24)
 
-      sog.shaped(
-          'ae2:crafting_unit',
-          ['AWA', 'CSC', 'AWA'],
-          {
-              A: 'gtceu:titanium_ingot',
-              W: 'gtceu:cpu_chip',
-              C: 'enderio:dense_me_conduit',
-              S: '#gtceu:circuits/hv'
-          }
-      ).id('ae2:unit')
-      sog.shaped(
-        'ae2:pattern_provider',
-        ['AWA', 'C C', 'AWA'],
-        {
-            A: 'gtceu:titanium_ingot',
-            W: 'gtceu:cpu_chip',
-            C: 'enderio:dense_me_conduit'
-        }
-      ).id('ae2:patternprov')
-      sog.shaped(
-        'ae2:molecular_assembler',
-        ['AWA', 'C C', 'AWA'],
-        {
-            A: 'gtceu:titanium_ingot',
-            W: 'gtceu:cpu_chip',
-            C: 'solarflux:photovoltaic_cell_1'
-        }
-      ).id('ae2:molecularasse')
-      sog.recipes.gtceu.assembler('pattern')
-          .itemInputs('8x solarflux:mirror', 'gtceu:aluminium_ingot', 'ae2:calculation_processor')
-          .inputFluids('gtceu:lubricant 63')
-          .itemOutputs('8x ae2:blank_pattern')
-          .duration(60)
-          .EUt(2048)
-      sog.recipes.gtceu.alloy_smelter('skystonedust')
-          .itemInputs('ae2:fluix_crystal', 'gtceu:stone_dust')
-          .itemOutputs('ae2:sky_dust')
-          .duration(60)
-          .EUt(32)
-      sog.recipes.gtceu.mixer('fluorine')
-          .itemInputs('64x gtceu:sulfur_dust')
-          .inputFluids('minecraft:water 1000')
-          .outputFluids('gtceu:fluorine 6000')
-          .duration(60)
-          .EUt(32)
-      sog.recipes.gtceu.centrifuge('rocksalt')
-          .itemInputs('32x gtceu:sulfur_dust')
-          .itemOutputs("8x gtceu:rock_salt_dust")
-          .duration(100)
-          .EUt(32)
-        exdeorum.setCrucibleHeatValueForState('minecraft:lightning_rod', 80);
-      sog.recipes.gtceu.centrifuge('ruthenium')
-          .itemInputs("gtceu:diamond_dust")
-          .itemOutputs("gtceu:ruthenium_dust")
-          .duration(400)
-          .EUt(32)
-                const gems = ["lapis", "sodalite", "lazurite"]
-      gems.forEach(gem => {
-        sog.recipes.gtceu.compressor(`${gem}_plate`)
-          .itemInputs(`gtceu:${gem}_dust`)
-          .itemOutputs(`gtceu:${gem}_plate`)
-          .duration(20 * 15)
-          .EUt(2)
-      })
-      sog.recipes.gtceu.arc_furnace('platinumsludge')
-          .itemInputs('gtceu:platinum_dust')
-          .inputFluids('gtceu:nitric_acid 1000')
-          .itemOutputs('4x gtceu:platinum_group_sludge_dust')
-          .duration(120)
-          .EUt(8192)
-      sog.shaped(
-            'gtceu:starextractor',
-            ['AWA', 'CSC', 'WCW'],
-            {
-                A: '#gtceu:circuits/iv',
-                W: 'gtceu:polybenzimidazole_plate',
-                C: '#gtceu:circuits/iv',
-                S: 'gtceu:iridium_frame'
-            }
-        ).id('gtceu:shaped/starextractor')
-    sog.recipes.gtceu.alloy_smelter('marble')
-        .itemInputs("gtceu:calcite_dust", 'exdeorum:compressed_cobblestone')
-        .itemOutputs("gtceu:marble")
+    sog.recipes.gtceu.assembler("pattern")
+        .itemInputs(
+            "8x solarflux:mirror",
+            "gtceu:aluminium_ingot",
+            "ae2:calculation_processor")
+        .inputFluids(
+            "gtceu:lubricant 63")
+        .itemOutputs(
+            "8x ae2:blank_pattern")
+        .duration(60)
+        .EUt(2048)
+
+    sog.recipes.gtceu.alloy_smelter("skystonedust")
+        .itemInputs(
+            "ae2:fluix_crystal",
+            "gtceu:stone_dust")
+        .itemOutputs(
+            "ae2:sky_dust")
+        .duration(60)
+        .EUt(32)
+
+    sog.recipes.gtceu.mixer("fluorine")
+        .itemInputs(
+            "64x gtceu:sulfur_dust")
+        .inputFluids(
+            "minecraft:water 1000")
+        .outputFluids(
+            "gtceu:fluorine 6000")
+        .duration(60)
+        .EUt(32)
+
+    sog.recipes.gtceu.centrifuge("rocksalt")
+        .itemInputs(
+            "32x gtceu:sulfur_dust")
+        .itemOutputs(
+            "8x gtceu:rock_salt_dust")
+        .duration(100)
+        .EUt(32)
+
+    sog.recipes.gtceu.centrifuge("ruthenium")
+        .itemInputs(
+            "gtceu:diamond_dust")
+        .itemOutputs(
+            "gtceu:ruthenium_dust")
+        .duration(400)
+        .EUt(32)
+
+    sog.recipes.gtceu.arc_furnace("platinumsludge")
+        .itemInputs(
+            "gtceu:platinum_dust")
+        .inputFluids(
+            "gtceu:nitric_acid 1000")
+        .itemOutputs(
+            "4x gtceu:platinum_group_sludge_dust")
+        .duration(120)
+        .EUt(8192)
+
+    sog.recipes.gtceu.alloy_smelter("marble")
+        .itemInputs(
+            "gtceu:calcite_dust",
+            "exdeorum:compressed_cobblestone")
+        .itemOutputs(
+            "gtceu:marble")
         .duration(4000)
         .EUt(32)
-    sog.recipes.gtceu.alloy_smelter('galliumarsenide')
-        .itemInputs('gtceu:arsenic_dust', 'gtceu:gallium_dust')
-        .itemOutputs('gtceu:gallium_arsenide_dust')
+
+    sog.recipes.gtceu.alloy_smelter("galliumarsenide")
+        .itemInputs(
+            "gtceu:arsenic_dust",
+            "gtceu:gallium_dust")
+        .itemOutputs(
+            "gtceu:gallium_arsenide_dust")
         .duration(4000)
         .EUt(32)
-    sog.recipes.gtceu.centrifuge('mattercentrifuge')
-        .inputFluids('gtceu:star_matter 100')
-        .itemOutputsRanged('gtceu:raw_beryllium', 1, 10)
-        .itemOutputsRanged('gtceu:raw_apatite', 10, 60)
-        .itemOutputsRanged('gtceu:raw_mica', 1, 10)
-        .itemOutputsRanged('gtceu:raw_oilsands', 40, 60)
-        .itemOutputsRanged('gtceu:raw_amethyst', 10, 60)
-        .itemOutputsRanged('gtceu:indium_dust', 2, 4)
-        .outputFluids('gtceu:tantalum_carbide 500')
+
+    sog.recipes.gtceu.centrifuge("mattercentrifuge")
+        .inputFluids(
+            "gtceu:star_matter 100")
+        .itemOutputsRanged(
+            "gtceu:raw_beryllium", 1, 10)
+        .itemOutputsRanged(
+            "gtceu:raw_apatite", 10, 60)
+        .itemOutputsRanged(
+            "gtceu:raw_mica", 1, 10)
+        .itemOutputsRanged(
+            "gtceu:raw_oilsands", 40, 60)
+        .itemOutputsRanged(
+            "gtceu:raw_amethyst", 10, 60)
+        .itemOutputsRanged(
+            "gtceu:indium_dust", 2, 4)
+        .outputFluids(
+            "gtceu:tantalum_carbide 500")
         .duration(4000)
         .EUt((GTValues.VA[GTValues.HV]))
-    sog.recipes.gtceu.electrolyzer('sodiumhydroxide')
-        .inputFluids([Fluid.of('gtceu:mercury', 500)])
-        .outputFluids([Fluid.of('gtceu:mercury_vapor', 1000)])
-        .itemOutputsRanged('gtceu:sodium_hydroxide_dust', 2, 15)
+
+    sog.recipes.gtceu.electrolyzer("sodiumhydroxide")
+        .inputFluids(
+            [Fluid.of("gtceu:mercury", 500)])
+        .outputFluids(
+            [Fluid.of("gtceu:mercury_vapor", 1000)])
+        .itemOutputsRanged(
+            "gtceu:sodium_hydroxide_dust", 2, 15)
         .duration(2000)
         .EUt((GTValues.VA[GTValues.LV]))
-    sog.recipes.gtceu.combustion_generator('mercurypower')
-        .inputFluids(Fluid.of('gtceu:mercury_vapor', 1000))
-        .duration(20*40).EUt(-(GTValues.V[GTValues.HV]))
-    sog.recipes.gtceu.autoclave('starmold')
-        .inputFluids(Fluid.of('gtceu:star_matter', 144))
-        .itemInputs('gtceu:empty_mold')
-        .itemOutputs('kubejs:star_extruder_mold')
+
+    sog.recipes.gtceu.combustion_generator("mercurypower")
+        .inputFluids(
+            Fluid.of("gtceu:mercury_vapor", 1000))
+        .duration(20*40)
+        .EUt(-(GTValues.V[GTValues.HV]))
+
+    sog.recipes.gtceu.autoclave("starmold")
+        .inputFluids(
+            Fluid.of("gtceu:star_matter", 144))
+        .itemInputs(
+            "gtceu:empty_mold")
+        .itemOutputs(
+            "kubejs:star_extruder_mold")
         .duration(2000)
         .EUt((GTValues.VA[GTValues.IV]))
-    sog.recipes.gtceu.autoclave('nether_star')
-        .inputFluids(Fluid.of('gtceu:star_matter', 144))
-        .notConsumable('kubejs:star_extruder_mold')
-        .itemOutputs('minecraft:nether_star')
+
+    sog.recipes.gtceu.autoclave("nether_star")
+        .inputFluids(
+            Fluid.of("gtceu:star_matter", 144))
+        .notConsumable(
+            "kubejs:star_extruder_mold")
+        .itemOutputs(
+            "minecraft:nether_star")
         .duration(20)
         .EUt((GTValues.VA[GTValues.LuV]))
-    sog.recipes.gtceu.chemical_reactor('raw_life_essence')
-        .itemInputs('16x minecraft:rotten_flesh')
-        .inputFluids(Fluid.of('gtceu:nitric_acid 1000'))
-        .outputFluids('gtceu:raw_life_essence 3000')
+
+    sog.recipes.gtceu.chemical_reactor("raw_life_essence")
+        .itemInputs(
+            "16x minecraft:rotten_flesh")
+        .inputFluids(
+            Fluid.of("gtceu:nitric_acid 1000"))
+        .outputFluids(
+            "gtceu:raw_life_essence 3000")
         .duration(200)
         .EUt((GTValues.VA[GTValues.IV]))
-    sog.recipes.gtceu.mixer('inert_life_essence')
-        .itemInputs('3x gtceu:epoxy_dust')
-        .inputFluids(Fluid.of('gtceu:raw_life_essence 3000'))
-        .outputFluids('gtceu:inert_life_essence 3000')
+
+    sog.recipes.gtceu.mixer("inert_life_essence")
+        .itemInputs(
+            "3x gtceu:epoxy_dust")
+        .inputFluids(
+            Fluid.of("gtceu:raw_life_essence 3000"))
+        .outputFluids(
+            "gtceu:inert_life_essence 3000")
         .duration(200)
         .EUt((GTValues.VA[GTValues.IV]))
-    sog.shaped(
-        'bloodmagic:altar',
-        ['A A', 'AWA', 'CCC'],
-        {
-            A: 'gtceu:indium_gallium_phosphide_ingot',
-            W: '#gtceu:circuits/luv',
-            C: 'gtceu:dense_rhodium_plated_palladium_plate'
-        }
-        ).id('bm:altar')
-    sog.recipes.gtceu.chemical_bath('processed_life_essence')
-        .notConsumable('bloodmagic:weakbloodorb')
-        .inputFluids(Fluid.of('gtceu:inert_life_essence 3000'))
-        .outputFluids('gtceu:processed_life_essence 3000')
+
+    sog.recipes.gtceu.chemical_bath("processed_life_essence")
+        .notConsumable(
+            "bloodmagic:weakbloodorb")
+        .inputFluids(
+            Fluid.of("gtceu:inert_life_essence 3000"))
+        .outputFluids(
+            "gtceu:processed_life_essence 3000")
         .duration(200)
         .EUt((GTValues.VA[GTValues.IV]))
-    sog.recipes.gtceu.autoclave('weakbloodorb_dupe')
-        .notConsumable('bloodmagic:weakbloodorb')
-        .inputFluids(Fluid.of('gtceu:inert_life_essence 3000'))
-        .itemOutputs('bloodmagic:weakbloodorb')
+
+    sog.recipes.gtceu.autoclave("weakbloodorb_dupe")
+        .notConsumable(
+            "bloodmagic:weakbloodorb")
+        .inputFluids(
+            Fluid.of("gtceu:inert_life_essence 3000"))
+        .itemOutputs(
+            "bloodmagic:weakbloodorb")
         .duration(400)
         .EUt((GTValues.VA[GTValues.IV]))
-    sog.recipes.gtceu.chemical_reactor('life_essence')
-        .notConsumable('bloodmagic:weakbloodorb')
-        .inputFluids(Fluid.of('gtceu:processed_life_essence 3000'))
-        .inputFluids(Fluid.of('gtceu:oxygen 1000'))
-        .outputFluids('bloodmagic:life_essence_fluid 7000')
+
+    sog.recipes.gtceu.chemical_reactor("life_essence")
+        .notConsumable(
+            "bloodmagic:weakbloodorb")
+        .inputFluids(
+            Fluid.of("gtceu:processed_life_essence 3000"))
+        .inputFluids(
+            Fluid.of("gtceu:oxygen 1000"))
+        .outputFluids(
+            "bloodmagic:life_essence_fluid 7000")
         .duration(200)
         .EUt((GTValues.VA[GTValues.IV]))
-    sog.recipes.gtceu.assembler('advancedtable')
-        .itemInputs('avaritia:double_compressed_crafting_table', 'gtceu:luv_machine_casing', '8x extendedcrafting:luminessence')
-        .inputFluids(Fluid.of('gtceu:polybenzimidazole 266'))
-        .itemOutputs('extendedcrafting:advanced_table')
+
+    sog.recipes.gtceu.assembler("advancedtable")
+        .itemInputs(
+            "avaritia:double_compressed_crafting_table",
+            "gtceu:luv_machine_casing",
+            "8x extendedcrafting:luminessence")
+        .inputFluids(
+            Fluid.of("gtceu:polybenzimidazole 266"))
+        .itemOutputs(
+            "extendedcrafting:advanced_table")
         .duration(500)
         .EUt(4)
-    sog.recipes.gtceu.forming_press('earth_globe')
-        .itemInputs(['64x exdeorum:compressed_diorite', '64x exdeorum:compressed_cobblestone', '64x exdeorum:compressed_granite', '64x exdeorum:compressed_andesite', '64x exdeorum:compressed_gravel'])
-        .notConsumable('extendedcrafting:nether_star_block')
-        .itemOutputs('ad_astra:earth_globe')
+
+    sog.recipes.gtceu.forming_press("earth_globe")
+        .itemInputs(["64x exdeorum:compressed_diorite",
+            "64x exdeorum:compressed_cobblestone",
+            "64x exdeorum:compressed_granite",
+            "64x exdeorum:compressed_andesite",
+            "64x exdeorum:compressed_gravel"])
+        .notConsumable(
+            "extendedcrafting:nether_star_block")
+        .itemOutputs(
+            "ad_astra:earth_globe")
         .duration(500)
-    sog.shaped(
-            'angelring:angel_ring',
-            ['A A', 'AWA', 'CCC'],
-            {
-                A: 'gtceu:manganese_phosphide_ingot',
-                W: 'gtceu:lv_field_generator',
-                C: 'gtceu:double_platinum_plate'
-            }
-            ).id('ag:angel_ring')
-    sog.recipes.gtceu.assembler('mars_globe')
-            .itemInputs('ad_astra:earth_globe', 'ad_astra:ostrum_block', '16x gtceu:cobalt_brass_ingot')
-            .inputFluids(Fluid.of('gtceu:polybenzimidazole 266'))
-            .itemOutputs('ad_astra:mars_globe')
-            .duration(500)
-            .EUt((GTValues.VA[GTValues.LuV]))
-    sog.recipes.gtceu.chemical_bath('meat')
-            .itemInputs('16x minecraft:rotten_flesh')
-            .inputFluids(Fluid.of('bloodmagic:life_essence_fluid 16000'))
-            .itemOutputs('minecraft:porkchop')
-            .duration(500)
-            .EUt((GTValues.VA[GTValues.HV]))
-    sog.recipes.gtceu.electric_blast_furnace('gtceu:ebf/resonant_naquadah')
-            .itemInputs('gtceu:resonant_naquadah_dust')
-            .inputFluids('gtceu:krypton 1000')
-            .itemOutputs('gtceu:resonant_naquadah_ingot')
-            .blastFurnaceTemp(9001)
-            .duration(1400)
-            .EUt(GTValues.VA[GTValues.UV]);
-    sog.recipes.gtceu.fusion_reactor('darmastadium')
-            .inputFluids('gtceu:resonant_naquadah 16', 'gtceu:ruthenium 16')
-            .outputFluids('gtceu:darmstadtium 32')
-            .fusionStartEU(200000000)
-            .duration(30)
-            .EUt((GTValues.VA[GTValues.LuV]))
-    sog.recipes.gtceu.autoclave('sky_steel')
-            .inputFluids(Fluid.of('gtceu:iron', 144))
-            .itemInputs('gtceu:certus_quartz_gem', 'ae2:sky_dust')
-            .itemOutputs('megacells:sky_steel_ingot')
-            .duration(20)
-            .EUt((GTValues.VA[GTValues.HV]))
-    sog.recipes.gtceu.circuit_assembler('accuprocess')
-            .itemInputs('ae2:silicon', 'minecraft:redstone', 'megacells:sky_steel_ingot')
-            .inputFluids('gtceu:lubricant 63')
-            .notConsumable('ae2:name_press')
-            .itemOutputs('megacells:accumulation_processor')
-            .duration(40)
-            .EUt(128)
-    sog.shapeless('minecraft:egg', [ 'minecraft:grass', 'hostilenetworks:overworld_prediction'])
-    sog.recipes.gtceu.bender('deshplate')
-            .itemInputs('ad_astra:desh_ingot')
-            .itemOutputs('ad_astra:desh_plate')
-            .circuit(1)
-            .duration(40)
-            .EUt(128)
-    sog.shapeless(
-        Item.of('gtmutils:neutronium_credit', 1),
-            ['8x gtmutils:naquadah_credit']
-    )
-    sog.shapeless(
-        Item.of('gtmutils:naquadah_credit', 1),
-            ['8x gtmutils:osmium_credit']
-    )
-    sog.shapeless(
-        Item.of('gtmutils:osmium_credit', 1),
-            ['8x gtmutils:platinum_credit']
-    )
-    sog.shapeless(
-        Item.of('gtmutils:platinum_credit', 1),
-            ['8x gtmutils:gold_credit']
-    )
-    sog.shapeless(
-        Item.of('gtmutils:gold_credit', 1),
-            ['8x gtmutils:silver_credit']
-    )
-    sog.shapeless(
-        Item.of('gtmutils:silver_credit', 1),
-            ['8x gtmutils:cupronickel_credit']
-    )
-        sog.shapeless(
-        Item.of('gtmutils:copper_credit', 8),
-            ['1x gtmutils:cupronickel_credit']
-    )
-    sog.shaped(
-            'gtceu:altart2',
-            ['ABA', 'CZC', 'CFC'],
-            {
-                A: 'gtceu:dense_rhodium_plated_palladium_plate',
-                B: 'gtceu:hsss_frame',
-                C: '#gtceu:circuits/luv',
-                Z: 'bloodmagic:altar',
-                F: 'megacells:bulk_cell_component'
-           }
-            ).id('sog:altart2')
-    sog.recipes.gtceu.assembler('atomic_casing')
-            .itemInputs('6x gtceu:atomic_alloy_frame', '4x gtceu:atomic_alloy_foil')
-            .inputFluids('gtceu:polybenzimidazole 63')
-            .circuit(24)
-            .itemOutputs('2x gtceu:atomic_casing')
-            .duration(40)
-            .EUt(524288)
-    sog.shaped(
-            'gtceu:mega_blast_furnace',
-            ['ABA', 'CZC', 'HBH'],
-            {
-                A: 'gtceu:dense_triplatirium_235_plate',
-                B: 'gtceu:atomic_casing',
-                Z: 'gtceu:electric_blast_furnace',
-                C: 'gtceu:zpm_field_generator',
-                H: 'gtceu:naquadah_alloy_buzz_saw_blade'
-           }
-            )
-    sog.shaped(
-            'gtceu:mega_vacuum_freezer',
-            ['ABA', 'CZC', 'HBH'],
-            {
-                A: 'gtceu:dense_triplatirium_235_plate',
-                B: 'gtceu:atomic_casing',
-                Z: 'gtceu:vacuum_freezer',
-                C: 'gtceu:zpm_field_generator',
-                H: 'gtceu:naquadah_alloy_buzz_saw_blade'
-           }
-            )
-    sog.shaped(
-            'gtceu:atomicforge',
-            ['ABA', 'CZC', 'CHC'],
-            {
-                A: 'gtceu:dense_atomic_alloy_plate',
-                B: 'gtceu:mega_blast_furnace',
-                Z: '#gtceu:circuits/uv',
-                C: 'gtceu:atomic_alloy_foil',
-                H: 'gtceu:zpm_fusion_reactor'
-           }
-            ).id('sog:atomicforge')
-            sog.shaped(
-                'gtceu:reinforced_atomicforge',
-                ['ABA', 'CZC', 'CHC'],
-                {
-                    A: 'gtceu:dense_zylon_plate',
-                    B: 'gtceu:atomicforge',
-                    Z: '#gtceu:circuits/uxv',
-                    C: 'gtceu:infinity_screw',
-                    H: 'gtceu:uev_fusion_reactor'
-               }
-                ).id('sog:reinforced_atomicforge')
-    sog.shaped(
-            'gtceu:starcondenser',
-            ['ABA', 'BZB', 'CCC'],
-            {
-                A: '#gtceu:circuits/uv',
-                B: 'gtceu:atomic_alloy_frame',
-                Z: 'kubejs:condensed_star_matter',
-                C: 'gtceu:atomic_casing'
-            }
-            ).id('sog:star_condenser')
-    sog.shaped(
-            'gtceu:blacklight',
-            ['ABA', 'HZH', 'ABA'],
-            {
-                A: 'gtceu:tungsten_carbide_gear',
-                B: 'gtceu:chemical_purple_dye',
-                Z: 'gtceu:purple_glass_lens',
-                H: 'gtceu:triplatirium_235_foil'
-            }
-            ).id('gt:blacklight')
-    sog.recipes.gtceu.electric_blast_furnace('hasoc')
-            .itemInputs('gtceu:advanced_soc', 'kubejs:condensed_star_matter')
-            .inputFluids('gtceu:sulfuric_acid 1000')
-            .itemOutputs('8x gtceu:highly_advanced_soc')
-            .blastFurnaceTemp(12000)
-            .duration(160)
-            .EUt(GTValues.VA[GTValues.UHV]);
-sog.recipes.gtceu.implosion_compressor('ae2:quantumsingularity')
-            .itemInputs('gtceu:industrial_tnt', 'ae2:singularity', 'minecraft:ender_pearl')
-            .itemOutputs('2x ae2:quantum_entangled_singularity')
-            .duration(160)
-            .EUt(GTValues.VA[GTValues.UHV]);
-sog.recipes.gtceu.implosion_compressor('gtceu:ic/crystal_matrix')
-            .itemInputs('4x gtceu:industrial_tnt', '64x avaritia:diamond_lattice')
-            .itemOutputs('1x gtceu:crystal_matrix_ingot')
-            .duration(5)
-            .EUt(GTValues.VA[GTValues.UHV]);
-sog.shaped(
-                'avaritia:diamond_lattice',
-                [' BA', 'BBB', 'AB '],
-                {
-                    A: 'gtceu:quantum_star',
-                    B: 'gtceu:diamond_plate'
-               }
-                ).id('sog:lattice')
-sog.recipes.gtceu.implosion_compressor('gtceu:ic/draconiccore')
-            .itemInputs('4x gtceu:industrial_tnt', '4x gtceu:dense_crystal_matrix_plate', '8x draconicevolution:draconium_dust')
-            .itemOutputs('64x draconicevolution:draconium_core')
-            .duration(5)
-            .EUt(GTValues.VA[GTValues.UHV]);
-sog.shaped(
-                'draconicevolution:particle_generator',
-                ['ABA', 'BZB', 'ABA'],
-                {
-                    A: 'gtceu:neutronium_plate',
-                    B: 'kubejs:fallen_singularity',
-                    Z: 'draconicevolution:draconium_core'
-               }
-                ).id('de:particlegen')
-sog.shaped(
-                'draconicevolution:energy_core_stabilizer',
-                ['ABA', 'BZB', 'ABA'],
-                {
-                    A: 'gtceu:dense_crystal_matrix_plate',
-                    B: 'kubejs:quantum_energy_capsule',
-                    Z: 'draconicevolution:particle_generator'
-                }
-                ).id('de:energycore')
-sog.shaped(
-                'gtceu:dimensional_matter_extractor',
-                ['AHA', 'BZB', 'ABA'],
-                {
-                    A: 'gtceu:atomic_casing',
-                    B: 'draconicevolution:energy_core_stabilizer',
-                    Z: 'gtceu:uhv_machine_hull',
-                    H: 'kubejs:gravitational_containment_cell'
-                }
-                ).id('sog:dimensionalextractor')
-sog.shaped(
-    'kubejs:neutronate_enriched_atomic_casing',
-    [' B ', 'BAB', ' B '],
-    {
-        A: 'gtceu:atomic_casing',
-        B: 'gtceu:ruthenium_trinium_americium_neutronate_hex_wire',
-    }
-    ).id('sog:neutronate')
-sog.shaped(
-        '2x minecraft:paper',
-        ['BBB', 'BAB', 'BBB'],
-        {
-            A: Item.of('minecraft:water_bucket'),
-            B: 'gtceu:wood_dust',
-        }).replaceIngredient({item: Item.of('minecraft:water_bucket')}, 'minecraft:bucket')
-        sog.recipes.gtceu.thermal_centrifuge('gtceu:tc/paper')
-        .itemInputs('minecraft:sugar_cane')
-        .itemOutputs('minecraft:paper')
+
+    sog.recipes.gtceu.assembler("mars_globe")
+        .itemInputs(
+            "ad_astra:earth_globe",
+            "ad_astra:ostrum_block",
+            "16x gtceu:cobalt_brass_ingot")
+        .inputFluids(
+            Fluid.of("gtceu:polybenzimidazole 266"))
+        .itemOutputs(
+            "ad_astra:mars_globe")
+        .duration(500)
+        .EUt((GTValues.VA[GTValues.LuV]))
+
+    sog.recipes.gtceu.chemical_bath("meat")
+        .itemInputs(
+            "16x minecraft:rotten_flesh")
+        .inputFluids(
+            Fluid.of("bloodmagic:life_essence_fluid 16000"))
+        .itemOutputs(
+            "minecraft:porkchop")
+        .duration(500)
+        .EUt((GTValues.VA[GTValues.HV]))
+
+    sog.recipes.gtceu.electric_blast_furnace("gtceu:ebf/resonant_naquadah")
+        .itemInputs(
+            "gtceu:resonant_naquadah_dust")
+        .inputFluids(
+            "gtceu:krypton 1000")
+        .itemOutputs(
+            "gtceu:resonant_naquadah_ingot")
+        .blastFurnaceTemp(9001)
+        .duration(1400)
+        .EUt(GTValues.VA[GTValues.UV]);
+
+    sog.recipes.gtceu.fusion_reactor("darmastadium")
+        .inputFluids(
+            "gtceu:resonant_naquadah 16",
+            "gtceu:ruthenium 16")
+        .outputFluids(
+            "gtceu:darmstadtium 32")
+        .fusionStartEU(200000000)
+        .duration(30)
+        .EUt((GTValues.VA[GTValues.LuV]))
+
+    sog.recipes.gtceu.autoclave("sky_steel")
+        .inputFluids(
+            Fluid.of("gtceu:iron", 144))
+        .itemInputs(
+            "gtceu:certus_quartz_gem",
+            "ae2:sky_dust")
+        .itemOutputs(
+            "megacells:sky_steel_ingot")
+        .duration(20)
+        .EUt((GTValues.VA[GTValues.HV]))
+
+    sog.recipes.gtceu.circuit_assembler("accuprocess")
+        .itemInputs(
+            "ae2:silicon",
+            "minecraft:redstone",
+            "megacells:sky_steel_ingot")
+        .inputFluids(
+            "gtceu:lubricant 63")
+        .notConsumable(
+            "ae2:name_press")
+        .itemOutputs(
+            "megacells:accumulation_processor")
+        .duration(40)
+        .EUt(128)
+
+    sog.recipes.gtceu.bender("deshplate")
+        .itemInputs(
+            "ad_astra:desh_ingot")
+        .itemOutputs(
+            "ad_astra:desh_plate")
+        .circuit(1)
+        .duration(40)
+        .EUt(128)
+
+    sog.recipes.gtceu.assembler("atomic_casing")
+        .itemInputs(
+            "6x gtceu:atomic_alloy_frame",
+            "4x gtceu:atomic_alloy_foil")
+        .inputFluids(
+            "gtceu:polybenzimidazole 63")
+        .circuit(24)
+        .itemOutputs(
+            "2x gtceu:atomic_casing")
+        .duration(40)
+        .EUt(524288)
+
+    sog.recipes.gtceu.electric_blast_furnace("hasoc")
+        .itemInputs(
+            "gtceu:advanced_soc",
+            "kubejs:condensed_star_matter")
+        .inputFluids(
+            "gtceu:sulfuric_acid 1000")
+        .itemOutputs(
+            "8x gtceu:highly_advanced_soc")
+        .blastFurnaceTemp(12000)
+        .duration(160)
+        .EUt(GTValues.VA[GTValues.UHV]);
+
+    sog.recipes.gtceu.implosion_compressor("ae2:quantumsingularity")
+        .itemInputs(
+            "gtceu:industrial_tnt",
+            "ae2:singularity",
+            "minecraft:ender_pearl")
+        .itemOutputs(
+            "2x ae2:quantum_entangled_singularity")
+        .duration(160)
+        .EUt(GTValues.VA[GTValues.UHV]);
+
+    sog.recipes.gtceu.implosion_compressor("gtceu:ic/crystal_matrix")
+        .itemInputs(
+            "4x gtceu:industrial_tnt",
+            "64x avaritia:diamond_lattice")
+        .itemOutputs(
+            "1x gtceu:crystal_matrix_ingot")
+        .duration(5)
+        .EUt(GTValues.VA[GTValues.UHV]);
+
+    sog.recipes.gtceu.implosion_compressor("gtceu:ic/draconiccore")
+        .itemInputs(
+            "4x gtceu:industrial_tnt",
+            "4x gtceu:dense_crystal_matrix_plate",
+            "8x draconicevolution:draconium_dust")
+        .itemOutputs(
+            "64x draconicevolution:draconium_core")
+        .duration(5)
+        .EUt(GTValues.VA[GTValues.UHV]);
+
+    sog.recipes.gtceu.thermal_centrifuge("gtceu:tc/paper")
+        .itemInputs(
+            "minecraft:sugar_cane")
+        .itemOutputs(
+            "minecraft:paper")
         .duration(5)
         .EUt(GTValues.VA[GTValues.MV]);
-        sog.recipes.gtceu.thermal_centrifuge('gtceu:tc/leather')
-        .itemInputs('minecraft:rotten_flesh')
-        .itemOutputs('minecraft:leather')
+
+    sog.recipes.gtceu.thermal_centrifuge("gtceu:tc/leather")
+        .itemInputs(
+            "minecraft:rotten_flesh")
+        .itemOutputs(
+            "minecraft:leather")
         .duration(5)
         .EUt(GTValues.VA[GTValues.LV]);
 
-sog.shaped(
-    'gtceu:mv_electric_extractinator',
-    ['ABC', 'DEF', 'BGA'],
-    {
-        A: 'gtceu:mv_robot_arm',
-        B: 'gtceu:transistor',
-        C: 'gtceu:vanadium_steel_gear',
-        D: 'gtceu:mv_conveyor_module',
-        E: 'gtceu:mv_machine_hull',
-        F: 'gtceu:mv_sensor',
-        G: 'extractinator:extractinator',
-    }
-)
-sog.shaped(
-    'gtceu:hv_electric_extractinator',
-    ['ABC', 'DEF', 'GHA'],
-    {
-        A: 'gtceu:hv_robot_arm',
-        B: 'ae2:engineering_processor',
-        C: 'gtceu:double_platinum_plate',
-        D: 'gtceu:hv_conveyor_module',
-        E: 'gtceu:hv_machine_hull',
-        F: 'gtceu:hv_sensor',
-        G: 'gtceu:lv_field_generator',
-        H: 'extractinator:extractinator',
-    }
-)
-sog.shaped(
-    'gtceu:ev_electric_extractinator',
-    ['ABC', 'DEF', 'GHA'],
-    {
-        A: 'gtceu:ev_robot_arm',
-        B: 'gtceu:ev_voltage_coil',
-        C: 'gtceu:ultimet_gear',
-        D: 'gtceu:ev_conveyor_module',
-        E: 'gtceu:ev_machine_hull',
-        F: '#gtceu:circuits/ev',
-        G: 'gtceu:mpic_chip',
-        H: 'extractinator:extractinator',
-    }
-)        
-sog.shaped(
-    'gtceu:iv_electric_extractinator',
-    ['ABC', 'DEF', 'GHA'],
-    {
-        A: 'gtceu:iv_robot_arm',
-        B: 'gtceu:iv_voltage_coil',
-        C: 'gtceu:osmiridium_gear',
-        D: 'gtceu:iv_conveyor_module',
-        E: 'gtceu:iv_machine_hull',
-        F: 'gtceu:iv_sensor',
-        G: 'minecraft:nether_star',
-        H: 'extractinator:extractinator',
-
-    }
-)
-sog.shaped(
-    'gtceu:luv_electric_extractinator',
-    ['ABC', 'DEF', 'GHA'],
-    {
-        A: 'gtceu:luv_robot_arm',
-        B: 'gtceu:luv_voltage_coil',
-        C: 'gtceu:osmiridium_gear',
-        D: 'gtceu:luv_conveyor_module',
-        E: 'gtceu:luv_machine_hull',
-        F: 'gtceu:luv_sensor',
-        G: 'gtceu:quantum_star',
-        H: 'extractinator:extractinator',
-
-    }
-)
-sog.shaped(
-    'gtceu:zpm_electric_extractinator',
-    ['ABC', 'DEF', 'GHA'],
-    {
-        A: 'gtceu:zpm_robot_arm',
-        B: 'gtceu:zpm_voltage_coil',
-        C: 'gtceu:naquadah_alloy_gear',
-        D: 'gtceu:zpm_conveyor_module',
-        E: 'gtceu:zpm_machine_hull',
-        F: 'gtceu:zpm_sensor',
-        G: 'gtceu:quantum_star',
-        H: 'extractinator:extractinator',
-
-    }
-)
-sog.shaped(
-    'gtceu:uv_electric_extractinator',
-    ['ABC', 'DEF', 'GHA'],
-    {
-        A: 'gtceu:uv_robot_arm',
-        B: 'gtceu:uv_voltage_coil',
-        C: 'gtceu:small_darmstadtium_gear',
-        D: 'gtceu:uv_conveyor_module',
-        E: 'gtceu:uv_machine_hull',
-        F: 'gtceu:uv_sensor',
-        G: 'gtceu:quantum_star',
-        H: 'extractinator:extractinator',
-
-    }
-)
-sog.shaped(
-    'gtceu:uhv_electric_extractinator',
-    ['ABC', 'DEF', 'GHA'],
-    {
-        A: 'gtceu:uhv_robot_arm',
-        B: 'kubejs:uhv_voltage_coil',
-        C: 'gtceu:neutronium_gear',
-        D: 'gtceu:uhv_conveyor_module',
-        E: 'gtceu:uhv_machine_hull',
-        F: 'gtceu:uhv_sensor',
-        G: 'gtceu:gravi_star',
-        H: 'extractinator:extractinator',
-
-    }
-)
-sog.shaped(
-    'gtceu:uev_electric_extractinator',
-    ['ABC', 'DEF', 'GHA'],
-    {
-        A: 'gtceu:uev_robot_arm',
-        B: 'kubejs:uev_voltage_coil',
-        C: 'gtceu:resonant_essence_gear',
-        D: 'gtceu:uev_conveyor_module',
-        E: 'gtceu:uev_machine_hull',
-        F: 'gtceu:uev_sensor',
-        G: 'gtceu:gravi_star',
-        H: 'extractinator:extractinator',
-
-    }
-)
-sog.shaped(
-    'gtceu:uiv_electric_extractinator',
-    ['ABC', 'DEF', 'GHA'],
-    {
-        A: 'gtceu:uiv_robot_arm',
-        B: 'kubejs:uiv_voltage_coil',
-        C: 'gtceu:draconium_gear',
-        D: 'gtceu:uiv_conveyor_module',
-        E: 'gtceu:uiv_machine_hull',
-        F: 'gtceu:uiv_sensor',
-        G: 'gtceu:gravi_star',
-        H: 'extractinator:extractinator',
-
-    }
-)
-sog.shaped(
-    'gtceu:uxv_electric_extractinator',
-    ['ABC', 'DEF', 'GHA'],
-    {
-        A: 'gtceu:uxv_robot_arm',
-        B: 'kubejs:uxv_voltage_coil',
-        C: 'gtceu:awakened_draconium_gear',
-        D: 'gtceu:uxv_conveyor_module',
-        E: 'gtceu:uxv_machine_hull',
-        F: 'gtceu:uxv_sensor',
-        G: 'gtceu:gravi_star',
-        H: 'extractinator:extractinator',
-
-    }
-)
-sog.shaped(
-    'gtceu:robust_extractinator',
-    ['ABC', 'DEF', 'GHA'],
-    {
-        A: 'gtceu:iv_robot_arm',
-        B: 'gtceu:iv_voltage_coil',
-        C: 'gtceu:osmiridium_gear',
-        D: 'gtceu:iv_conveyor_module',
-        E: 'gtceu:iv_electric_extractinator',
-        F: 'gtceu:iv_sensor',
-        G: 'gtceu:quantum_star',
-        H: '#gtceu:circuits/luv',
-
-    }
-)
-sog.shaped(
-    'gtceu:atomicompressor',
-    ['ABA', 'CDC', 'AEA'],
-    {
-        A: 'kubejs:exotic_matter',
-        B: 'kubejs:stabilized_collapsed_singularity',
-        C: 'kubejs:stable_matter',
-        D: 'gtceu:implosion_compressor',
-        E: 'draconicevolution:energy_core_stabilizer'
-
-    }
-)
-sog.recipes.gtceu.fusion_reactor('reactmatter')
-        .inputFluids('gtceu:antimatter 1000', 'gtceu:star_matter 10000')
-        .outputFluids('gtceu:reactable_fissioned_matter_plasma 10000')
+    sog.recipes.gtceu.fusion_reactor("reactmatter")
+        .inputFluids(
+            "gtceu:antimatter 1000",
+            "gtceu:star_matter 10000")
+        .outputFluids(
+            "gtceu:reactable_fissioned_matter_plasma 10000")
         .fusionStartEU(640000000)
         .duration(30)
         .EUt((GTValues.VA[GTValues.UHV]))
 
+    sog.recipes.gtceu.assembler("neutronium_casing")
+        .itemInputs(
+            "6x gtceu:neutronium_frame",
+            "4x gtceu:neutronium_foil")
+        .inputFluids(
+            "gtceu:polybenzimidazole 63")
+        .circuit(24)
+        .itemOutputs(
+            "2x kubejs:neutronium_casing")
+        .duration(40)
+        .EUt(GTValues.VA[GTValues.UV]);
 
-sog.shaped(
-    'kubejs:quantum_resonant_core',
-    ['ABA', 'BZB', 'ABA'],
-    {
-        A: 'gtceu:uv_field_generator',
-        B: 'kubejs:stabilized_collapsed_singularity',
-        Z: 'kubejs:atomically_compressed_black_hole'
-})
-sog.recipes.gtceu.assembler('neutronium_casing')
-.itemInputs('6x gtceu:neutronium_frame', '4x gtceu:neutronium_foil')
-.inputFluids('gtceu:polybenzimidazole 63')
-.circuit(24)
-.itemOutputs('2x kubejs:neutronium_casing')
-.duration(40)
-.EUt(GTValues.VA[GTValues.UV]);
-sog.shaped(
-    'gtceu:supercriticalvibrationsifter',
-    ['ABA', 'YZC', 'YKL'],
-    {
-        A: 'gtceu:uv_field_generator',
-        B: 'kubejs:quantum_resonant_core',
-        Z: 'gtceu:uhv_machine_hull',
-        C: 'gtceu:uv_emitter',
-        Y: 'gtceu:uv_robot_arm',
-        K: 'kubejs:gravitational_containment_cell',
-        L: 'gtceu:uhv_ultimate_battery'
-})
-sog.recipes.gtceu.alloy_smelter('copperalloy')
-.itemInputs('2x gtceu:annealed_copper_ingot', 'gtceu:red_alloy_ingot')
-.itemOutputs('4x enderio:copper_alloy_ingot')
-.duration(100)
-.EUt(32)
-sog.recipes.gtceu.alloy_smelter('energeticalloy')
-.itemInputs('24x minecraft:glowstone_dust', 'enderio:copper_alloy_ingot')
-.itemOutputs('4x enderio:energetic_alloy_ingot')
-.duration(100)
-.EUt(32)
-sog.recipes.gtceu.alloy_smelter('vibrantalloy')
-.itemInputs('8x gtceu:aluminium_ingot', 'enderio:pulsating_alloy_ingot')
-.itemOutputs('4x enderio:vibrant_alloy_ingot')
-.duration(100)
-.EUt(32)
-sog.recipes.gtceu.alloy_smelter('endsteel')
-.itemInputs('2x gtceu:steel_ingot', '16x minecraft:end_stone')
-.itemOutputs('4x enderio:end_steel_ingot')
-.duration(100)
-.EUt(32)
-sog.recipes.gtceu.alloy_smelter('darksteel')
-.itemInputs('2x gtceu:steel_ingot', 'enderio:soularium_ingot')
-.itemOutputs('4x enderio:dark_steel_ingot')
-.duration(100)
-.EUt(32)
-sog.shaped(
-    'enderio:ender_crystal',
-    [' A ', 'ABA', ' A '],
-    {
-        A: 'minecraft:ender_pearl',
-        B: 'enderio:vibrant_crystal',
-})
-sog.recipes.gtceu.autoclave('condensed_nether_star')
-.inputFluids(Fluid.of('gtceu:condensed_star_matter', 144))
-.notConsumable('kubejs:star_extruder_mold')
-.itemOutputs('16x minecraft:nether_star')
-.duration(20)
-.EUt((GTValues.VA[GTValues.LuV]))
-sog.recipes.gtceu.assembler('uhv_voltage_coil')
-.itemInputs('gtceu:magnetic_samarium_rod', '16x gtceu:fine_neutronium_wire')
-.circuit(1)
-.itemOutputs('kubejs:uhv_voltage_coil')
-.duration(200)
-.EUt(GTValues.VA[GTValues.UHV]);
-sog.recipes.gtceu.assembler('uev_voltage_coil')
-.itemInputs('gtceu:magnetic_samarium_rod', '16x gtceu:fine_draconium_wire')
-.circuit(1)
-.itemOutputs('kubejs:uev_voltage_coil')
-.duration(400)
-.EUt(GTValues.VA[GTValues.UHV]);
-sog.shaped(
-    'minecraft:netherite_upgrade_smithing_template',
-    ['ABA', 'AZA', 'AAA'],
-    {
-        A: 'minecraft:diamond',
-        B: 'minecraft:netherite_scrap',
-        Z: 'minecraft:netherrack'
-})
-sog.recipes.gtceu.bender('ostrum_plate')
-.itemInputs('ad_astra:ostrum_ingot')
-.itemOutputs('ad_astra:ostrum_plate')
-.circuit(1)
-.duration(40)
-.EUt(128)
-sog.recipes.gtceu.bender('saturlyte_plate')
-.itemInputs('ad_extendra:saturlyte_ingot')
-.itemOutputs('ad_extendra:saturlyte_plate')
-.circuit(1)
-.duration(40)
-.EUt(128)
-sog.shaped(
-    'ad_astra:rocket_fin',
-    [' A ', 'ABA', 'ABA'],
-    {
-        A: 'gtceu:dense_stainless_steel_plate',
-        B: 'gtceu:smd_inductor'
-})
-sog.shaped(
-    'ad_astra:rocket_nose_cone',
-    [' A ', 'BGB', 'BHB'],
-    {
-        A: 'minecraft:lightning_rod',
-        B: 'gtceu:dense_magnetic_steel_plate',
-        G: 'gtceu:lv_field_generator',
-        H: 'gtceu:steel_block'
-})
-sog.shaped(
-    'ad_astra:fan',
-    [' A ', 'ABA', ' A '],
-    {
-        A: 'gtceu:long_iron_rod',
-        B: 'gtceu:steel_rotor'
-})
-sog.shaped(
-    'ad_astra:engine_frame',
-    ['ABB', 'AZA', 'BBA'],
-    {
-        B: 'gtceu:dense_stainless_steel_plate',
-        A: 'gtceu:long_iron_rod',
-        Z: 'gtceu:lv_field_generator'
-})
-sog.shaped(
-    'ad_astra:oxygen_gear',
-    ['A A', 'BHB', 'FGF'],
-    {
-        A: 'ad_astra:oxygen_tank',
-        B: 'gtceu:dense_stainless_steel_plate',
-        H: 'gtceu:long_iron_rod',
-        F: 'gtceu:blue_steel_buzz_saw_blade',
-        G: 'gtceu:blue_steel_frame'
-})
-sog.shaped(
-    'ad_astra:gas_tank',
-    ['ABC', 'ADE', 'AFC'],
-    {
-        A: 'gtceu:dense_stainless_steel_plate',
-        C: 'gtceu:smd_transistor',
-        B: 'gtceu:long_iron_rod',
-        D: 'gtceu:mask_filter',
-        E: 'gtceu:stainless_steel_drum',
-        F: 'gtceu:hv_battery_hull'
-})
-sog.recipes.gtceu.mixer('mixed_alloy')
-.itemInputs('7x gtceu:copper_dust', '4x gtceu:tin_dust', '11x gtceu:iron_dust')
-.itemOutputs('22x gtceu:mixed_alloy_dust')
-.circuit(4)
-.duration(200)
-.EUt((GTValues.VA[GTValues.MV]))
-sog.recipes.gtceu.mixer('heavy_duty_alloy_t1')
-.itemInputs('16x gtceu:mixed_alloy_dust', '4x gtceu:steel_dust', '11x gtceu:iron_dust')
-.inputFluids(Fluid.of('gtceu:stainless_steel 144'))
-.itemOutputs('gtceu:hot_heavy_duty_alloy_t1_ingot')
-.circuit(4)
-.duration(200)
-.EUt((GTValues.VA[GTValues.HV]))
-sog.recipes.gtceu.mixer('heavy_duty_alloy_t2')
-.itemInputs('7x gtceu:platinum_dust', '4x gtceu:osmiridium_dust', '11x gtceu:tantalum_carbide_dust', 'gtceu:heavy_duty_alloy_t1_dust')
-.inputFluids(Fluid.of('gtceu:rhodium_plated_palladium 144'))
-.itemOutputs('gtceu:hot_heavy_duty_alloy_t2_ingot')
-.circuit(4)
-.duration(200)
-.EUt((GTValues.VA[GTValues.LuV]))
-sog.recipes.gtceu.mixer('heavy_duty_alloy_t3')
-.itemInputs('7x gtceu:ruthenium_trinium_americium_neutronate_dust', '4x gtceu:triplatirium_235_dust', '11x gtceu:atomic_alloy_dust', 'gtceu:heavy_duty_alloy_t2_dust')
-.inputFluids(Fluid.of('gtceu:condensed_star_matter 144'))
-.itemOutputs('gtceu:hot_heavy_duty_alloy_t3_ingot')
-.circuit(4)
-.duration(200)
-.EUt((GTValues.VA[GTValues.UHV]))
-sog.recipes.gtceu.implosion_compressor('gtceu:ic/hdat3')
-.itemInputs('4x gtceu:industrial_tnt', 'gtceu:hot_heavy_duty_alloy_t3_ingot')
-.itemOutputs('gtceu:heavy_duty_alloy_t3_ingot')
-.duration(5)
-.EUt(GTValues.VA[GTValues.UHV]);
-sog.recipes.gtceu.implosion_compressor('gtceu:ic/hdat2')
-.itemInputs('64x minecraft:tnt', 'gtceu:hot_heavy_duty_alloy_t2_ingot')
-.itemOutputs('gtceu:heavy_duty_alloy_t2_ingot')
-.duration(5)
-.EUt(GTValues.VA[GTValues.LuV]);
-sog.recipes.gtceu.implosion_compressor('gtceu:ic/hdat1')
-.itemInputs('64x minecraft:tnt', 'gtceu:hot_heavy_duty_alloy_t1_ingot')
-.itemOutputs('gtceu:heavy_duty_alloy_t1_ingot')
-.duration(5)
-.EUt(GTValues.VA[GTValues.LV]);
-sog.recipes.gtceu.implosion_compressor('gtceu:ic/hdat2itnt')
-.itemInputs('32x gtceu:industrial_tnt', 'gtceu:hot_heavy_duty_alloy_t2_ingot')
-.itemOutputs('gtceu:heavy_duty_alloy_t2_ingot')
-.duration(5)
-.EUt(GTValues.VA[GTValues.LuV]);
-sog.recipes.gtceu.implosion_compressor('gtceu:ic/hdat1itnt')
-.itemInputs('32x gtceu:industrial_tnt', 'gtceu:hot_heavy_duty_alloy_t1_ingot')
-.itemOutputs('gtceu:heavy_duty_alloy_t1_ingot')
-.duration(5)
-.EUt(GTValues.VA[GTValues.LV]);
-sog.shaped(
-    'gtceu:atomic_moonminer',
-    ['ABA', 'EDE', 'ABA'],
-    {
-        A: 'gtceu:atomic_casing',
-        B: 'gtceu:tritanium_coil_block',
-        D: 'gtceu:moonminer',
-        E: 'gtceu:wetware_processor_mainframe',
+    sog.recipes.gtceu.alloy_smelter("copperalloy")
+        .itemInputs(
+            "2x gtceu:annealed_copper_ingot",
+            "gtceu:red_alloy_ingot")
+        .itemOutputs(
+            "4x enderio:copper_alloy_ingot")
+        .duration(100)
+        .EUt(32)
 
-})
-sog.recipes.gtceu.autoclave('gtceu:ac/acidic_resonant_residue')
-.itemInputs('kubejs:primal_resonant_core')
-.inputFluids(Fluid.of('gtceu:acidic_venus_residue 144'))
-.outputFluids(Fluid.of('gtceu:resonant_essence_residue 1000'))
-.duration(100)
-.EUt(GTValues.VA[GTValues.UEV]);
-sog.recipes.gtceu.extractor('creative_data2')
-.itemInputs('64x #gtceu:circuits/uv')
-.itemOutputs('gtceu:creative_data_access_hatch')
-.duration(100)
-.EUt(GTValues.VA[GTValues.UV]);
-sog.recipes.gtceu.assembler('kaemite_casing')
-.itemInputs('6x gtceu:kaemite_frame', '4x gtceu:kaemite_foil')
-.inputFluids('gtceu:polybenzimidazole 63')
-.circuit(24)
-.itemOutputs('2x kubejs:kaemite_casing')
-.duration(40)
-.EUt(GTValues.VA[GTValues.UHV]);
-sog.shaped(
-    'kubejs:drilling_projector_module',
-    ['ABA', 'BZB', 'ABA'],
-    {
-        A: 'kubejs:gravitational_fluctuation_module',
-        B: 'gtceu:uv_parallel_hatch',
-        Z: 'gtceu:neutronium_drill_head'
-})
-sog.shaped(
-    'kubejs:pumping_projector_module',
-    ['ABA', 'BZB', 'ABA'],
-    {
-        A: 'kubejs:gravitational_fluctuation_module',
-        B: 'gtceu:uv_parallel_hatch',
-        Z: 'gtceu:uhv_electric_pump'
-})
-sog.shaped(
-    'kubejs:fusion_projector_module',
-    ['ABF', 'BZB', 'FBA'],
-    {
-        A: 'kubejs:gravitational_fluctuation_module',
-        B: 'avaritia:eternal_singularity',
-        Z: 'gtceu:uv_fusion_reactor',
-        F: 'gtceu:fine_cosmic_neutronium_wire'
-})
-sog.shaped(
-    'kubejs:cosmic_projector_module',
-    ['ABF', 'BZB', 'FBA'],
-    {
-        A: 'kubejs:gravitational_fluctuation_module',
-        B: 'avaritia:eternal_singularity',
-        Z: 'gtceu:uhv_quantum_tank',
-        F: 'kubejs:gravitational_containment_cell'
-})
-sog.recipes.gtceu.assembler('uevcasing')
-.itemInputs('8x gtceu:resonant_essence_plate')
-.circuit(8)
-.itemOutputs('gtceu:uev_machine_casing')
-.duration(50)
-.EUt(GTValues.VA[GTValues.LV]);
-sog.recipes.gtceu.large_chemical_reactor('hrcb')
-.itemInputs('2x gtceu:wetware_circuit_board', '64x gtceu:antimatter_foil', 'kubejs:antimatter_boule')
-.inputFluids(Fluid.of('gtceu:antimatter', 100))
-.itemOutputs('4x kubejs:highly_resonative_circuit_board')
-.cleanroom(CleanroomType.CLEANROOM)
-.duration(900)
-.EUt(GTValues.VA[GTValues.UEV]);
-sog.recipes.gtceu.large_chemical_reactor('hrcb2')
-.itemInputs('kubejs:highly_resonative_circuit_board', '32x gtceu:resonant_essence_single_wire')
-.inputFluids(Fluid.of('gtceu:antimatter', 100))
-.itemOutputs('kubejs:highly_resonative_printed_circuit_board')
-.cleanroom(CleanroomType.CLEANROOM)
-.duration(1800)
-.EUt(GTValues.VA[GTValues.UEV]);
-sog.recipes.gtceu.large_chemical_reactor('red_granite')
-.itemInputs('minecraft:granite')
-.inputFluids(Fluid.of('gtceu:redstone', 144))
-.circuit(8)
-.itemOutputs('gtceu:red_granite')
-.duration(100)
-.EUt(GTValues.VA[GTValues.EV]);
-sog.shapeless('minecraft:bamboo', ['minecraft:oak_sapling', 'minecraft:wheat_seeds', 'hostilenetworks:overworld_prediction'])
-sog.shapeless('minecraft:beetroot_seeds', ['minecraft:wheat_seeds', '2x hostilenetworks:overworld_prediction'])
-sog.shapeless('minecraft:pumpkin_seeds', ['minecraft:beetroot_seeds', 'minecraft:wheat_seeds', 'hostilenetworks:overworld_prediction'])
-sog.recipes.gtceu.autoclave('resonant_matrix')
-.inputFluids(Fluid.of('gtceu:resonant_naquadah', 144))
-.itemInputs('gtceu:crystal_matrix_ingot')
-.itemOutputs('avaritia:crystal_matrix_ingot')
-.duration(20)
-.EUt((GTValues.VA[GTValues.UHV]))
-sog.recipes.gtceu.mixer('energizedsuperconductor')
-.circuit(2)
-.itemInputs('4x gtceu:gold_dust', 'gtceu:coal_dust', '2x minecraft:redstone')
-.itemOutputs('3x gtceu:energized_superconductor_dust')
-.duration(100)
-.EUt(32)
-sog.recipes.gtceu.mixer('hscsuperconductor')
-.circuit(4)
-.itemInputs('4x gtceu:coal_dust', '4x gtceu:silicon_dust', '2x gtceu:annealed_copper_dust')
-.inputFluids('gtceu:oxygen 2000')
-.itemOutputs('3x gtceu:hsc_superconductor_dust')
-.duration(175)
-.EUt(128)
-sog.recipes.gtceu.mixer('platiumsuperconductor')
-.circuit(4)
-.itemInputs('1x gtceu:coal_dust', '4x gtceu:platinum_dust', '8x gtceu:energium_dust')
-.itemOutputs('4x gtceu:platium_superconductor_dust')
-.duration(275)
-.EUt(512)
-sog.recipes.gtceu.mixer('tilrunumsuperconductor')
-.circuit(4)
-.itemInputs('1x gtceu:titanium_dust', '4x gtceu:ruthenium_dust', '8x gtceu:molybdenum_dust')
-.itemOutputs('13x gtceu:tilrunum_superconductor_dust')
-.duration(175)
-.EUt(2048)
-sog.recipes.gtceu.autoclave('crystal_superconductor')
-.inputFluids(Fluid.of('gtceu:europium', 144))
-.itemInputs('gtceu:crystal_soc')
-.itemOutputs('4x gtceu:crystal_superconductor_ingot')
-.duration(380)
-.EUt((GTValues.VA[GTValues.ZPM]))
-sog.shaped(
-    'kubejs:end_miner_module',
-    ['ABA', 'BZB', 'ABA'],
-    {
-        A: 'minecraft:dragon_egg',
-        B: 'minecraft:dragon_breath',
-        Z: 'draconicevolution:dragon_heart',
-})
-sog.recipes.gtceu.forming_press('cupro_credit')
-.itemInputs('gtceu:cupronickel_plate')
-.notConsumable('gtceu:cylinder_casting_mold')
-.itemOutputs('4x gtmutils:cupronickel_credit')
-.duration(100)
-.EUt((GTValues.VA[GTValues.LV]))
-sog.recipes.gtceu.forming_press('moonglobe')
-.itemInputs('gtceu:stainless_steel_block')
-.notConsumable('ae2:name_press')
-.notConsumable('ad_astra:moon_globe')
-.itemOutputs('ad_astra:moon_globe')
-.duration(500)
-.EUt((GTValues.VA[GTValues.HV]))
-sog.recipes.gtceu.centrifuge('magnaliumbismuth')
-.itemInputs('3x gtceu:magnalium_dust')
-.itemOutputs('1x gtceu:bismuth_dust')
-.duration(100)
-.EUt(32)
-sog.recipes.gtceu.centrifuge('californium')
-.itemInputs('3x gtceu:cleaned_californium_dust')
-.itemOutputs('1x gtceu:californium_dust')
-.duration(100)
-.EUt(32)
-sog.shaped(
-    'gtceu:bio_lab',
-    ['ABA', 'AZA', 'AFA'],
-    {
-        A: 'gtceu:plascrete',
-        B: 'gtceu:stem_cells',
-        Z: 'gtceu:uhv_hermetic_casing',
-        F: '#gtceu:circuits/uev'
-})
-sog.shaped(
-    'gtceu:large_bacterial_bat',
-    ['ABA', 'AZA', 'AFA'],
-    {
-        A: 'gtceu:plascrete',
-        B: 'gtceu:stem_cells',
-        Z: 'gtceu:petri_dish',
-        F: '#gtceu:circuits/uv'
-    })
+    sog.recipes.gtceu.alloy_smelter("energeticalloy")
+        .itemInputs(
+            "24x minecraft:glowstone_dust",
+            "enderio:copper_alloy_ingot")
+        .itemOutputs(
+            "4x enderio:energetic_alloy_ingot")
+        .duration(100)
+        .EUt(32)
 
-//Stabilized Iridium
+    sog.recipes.gtceu.alloy_smelter("vibrantalloy")
+        .itemInputs(
+            "8x gtceu:aluminium_ingot",
+            "enderio:pulsating_alloy_ingot")
+        .itemOutputs(
+            "4x enderio:vibrant_alloy_ingot")
+        .duration(100)
+        .EUt(32)
 
-sog.recipes.gtceu.mixer('neutronic_chromite')
-.circuit(4)
-.itemInputs('7x gtceu:chromium_dust', '4x gtceu:neutronium_dust')
-.itemOutputs('4x gtceu:neutronic_chromite_dust')
-.duration(275)
-.EUt((GTValues.VA[GTValues.UHV]))
-sog.recipes.gtceu.mixer('radium_infused_lead')
-.circuit(2)
-.itemInputs('6x gtceu:lead_dust', '2x gtceu:platinum_dust')
-.inputFluids('gtceu:radon 1000')
-.itemOutputs('4x gtceu:radium_infused_lead_dust')
-.duration(275)
-.EUt((GTValues.VA[GTValues.EV]))
-sog.recipes.gtceu.mixer('stabilized_iridium_dust')
-.circuit(3)
-.itemInputs('19x gtceu:iridium_dust', '4x gtceu:osmium_dust', '8x gtceu:neutronic_chromite_dust', 'gtceu:radium_infused_lead_dust')
-.itemOutputs('4x gtceu:stabilized_iridium_dust')
-.duration(275)
-.EUt((GTValues.VA[GTValues.UHV]))
-sog.recipes.gtceu.mixer('californite')
-.circuit(4)
-.itemInputs('19x gtceu:californium_dust', '8x gtceu:stabilized_iridium_dust')
-.itemOutputs('4x gtceu:californite_dust')
-.duration(275)
-.EUt((GTValues.VA[GTValues.UEV]))
-sog.recipes.gtceu.mixer('draconium')
-.circuit(1)
-.itemInputs('5x gtceu:hypoxylon_dust', '8x gtceu:stabilized_iridium_dust', '8x gtceu:ruthenium_trinium_americium_neutronate_dust', '2x gtceu:antimatter_dust')
-.itemOutputs('4x draconicevolution:draconium_dust')
-.duration(400)
-.EUt((GTValues.VA[GTValues.UEV]))
+    sog.recipes.gtceu.alloy_smelter("endsteel")
+        .itemInputs(
+            "2x gtceu:steel_ingot",
+            "16x minecraft:end_stone")
+        .itemOutputs(
+            "4x enderio:end_steel_ingot")
+        .duration(100)
+        .EUt(32)
 
-//
+    sog.recipes.gtceu.alloy_smelter("darksteel")
+        .itemInputs(
+            "2x gtceu:steel_ingot",
+            "enderio:soularium_ingot")
+        .itemOutputs(
+            "4x enderio:dark_steel_ingot")
+        .duration(100)
+        .EUt(32)
 
+    sog.recipes.gtceu.autoclave("condensed_nether_star")
+        .inputFluids(
+            Fluid.of("gtceu:condensed_star_matter", 144))
+        .notConsumable(
+            "kubejs:star_extruder_mold")
+        .itemOutputs(
+            "16x minecraft:nether_star")
+        .duration(20)
+        .EUt((GTValues.VA[GTValues.LuV]))
 
-    // Universal Circuits
-    const tiers = ["ulv", "lv", "mv", "hv", "ev", "iv", "luv", "zpm", "uv", "uhv", "uev", "uiv", "uxv", "opv"]
-        tiers.forEach((level) => {
-        sog.recipes.gtceu.forming_press("kubejs:" + level + "_universal_circuit")
-            .itemInputs("#gtceu:circuits/" + level)
-            .itemOutputs("kubejs:" + level + "_universal_circuit")
-            .EUt(32)
-            .duration(5)
-    })
-sog.recipes.gtceu.macerator('shattered')
-.itemInputs('advanced_ae:shattered_singularity')
-.itemOutputs('advanced_ae:quantum_infused_dust')
-.duration(15)
-.EUt(512)
-sog.recipes.gtceu.macerator('refined_apatite_ore_apatite')
-.itemInputs('gtceu:refined_apatite_ore')
-.itemOutputs('gtceu:apatite_dust')
-.duration(400)
-.EUt(2)
-sog.recipes.gtceu.circuit_assembler('quantumprocessor')
-.itemInputs('ae2:silicon', 'minecraft:redstone', 'advanced_ae:quantum_alloy')
-.inputFluids('gtceu:lubricant 63')
-.notConsumable('ae2:name_press')
-.itemOutputs('advanced_ae:quantum_processor')
-.duration(40)
-.EUt(2048)
+    sog.recipes.gtceu.assembler("uhv_voltage_coil")
+        .itemInputs(
+            "gtceu:magnetic_samarium_rod",
+            "16x gtceu:fine_neutronium_wire")
+        .circuit(1)
+        .itemOutputs(
+            "kubejs:uhv_voltage_coil")
+        .duration(200)
+        .EUt(GTValues.VA[GTValues.UHV]);
 
-sog.shaped(
-    'kubejs:component_tile_casing',
-    ['AAA', 'ABA', 'AAA'],
-    {
-        A: 'gtceu:cosmic_titanium_plate',
-        B: 'gtceu:tritanium_frame'
-})
-sog.shaped(
-    'kubejs:large_precision_casing',
-    ['AAA', 'ABA', 'AAA'],
-    {
-        A: 'gtceu:cosmic_tungsten_plate',
-        B: 'gtceu:hypoxylon_frame'
-})
-sog.shaped(
-    'kubejs:reinforced_computation_casing',
-    ['AAA', 'ABA', 'AAA'],
-    {
-        A: 'gtceu:cosmic_iridium_plate',
-        B: 'gtceu:computer_casing'
-})
-sog.shaped(
-    '2x kubejs:highly_reinforced_radioactive_casing',
-    ['AAA', 'ABA', 'AAA'],
-    {
-        A: 'gtceu:stabilized_iridium_plate',
-        B: 'kubejs:californite_heavy_plating'
-})
-sog.shaped(
-    '2x kubejs:stellar_powered_casing',
-    ['AAA', 'EBE', 'AAA'],
-    {
-        E: 'kubejs:draconium_heavy_plating',
-        A: 'gtceu:dense_antimatter_plate',
-        B: 'kubejs:highly_reinforced_radioactive_casing'
-})
-sog.shaped(
-    'gtceu:atmospheric_collector',
-    ['ABA', 'YCY', 'ABA'],
-    {
-        A: 'gtceu:luv_electric_pump',
-        B: 'gtceu:laminated_glass',
-        Y: '#gtceu:circuits/luv',
-        C: 'gtceu:luv_machine_hull'
-})
-sog.shaped(
-    'gtceu:particle_implosion_chamber',
-    ['ABA', 'YCY', 'ABA'],
-    {
-        A: 'gtceu:uhv_robot_arm',
-        B: 'gtceu:atomic_casing',
-        Y: '#gtceu:circuits/uhv',
-        C: 'gtceu:uhv_machine_hull'
-})
-sog.shaped(
-    'ae2:energy_acceptor',
-    ['ABA', 'BYB', 'ABA'],
-    {
-        A: 'gtceu:platinum_ingot',
-        B: 'gtceu:lpic_chip',
-        Y: 'gtceu:hv_machine_hull',
-})
-sog.shaped(
-    'ae2:interface',
-    ['ABA', 'BYC', 'ACA'],
-    {
-        A: 'gtceu:stainless_steel_ingot',
-        B: 'ae2:annihilation_core',
-        Y: 'enderio:me_conduit',
-        C: 'ae2:formation_core'
-})
-sog.shaped(
-    'ae2:import_bus',
-    ['ABA', 'BYB', '   '],
-    {
-        A: 'gtceu:stainless_steel_ingot',
-        B: 'ae2:formation_core',
-        Y: 'minecraft:sticky_piston',
-})
-sog.shaped(
-    'ae2:export_bus',
-    ['ABA', 'BYB', '   '],
-    {
-        A: 'gtceu:stainless_steel_ingot',
-        B: 'ae2:annihilation_core',
-        Y: 'minecraft:sticky_piston',
-})
-sog.shaped(
-    'avaritia:extreme_crafting_table',
-    ['BB ', 'AA ', '   '],
-    {
-        A: 'avaritia:crystal_matrix_ingot',
-        B: 'minecraft:flint',
-})
+    sog.recipes.gtceu.assembler("uev_voltage_coil")
+        .itemInputs(
+            "gtceu:magnetic_samarium_rod",
+            "16x gtceu:fine_draconium_wire")
+        .circuit(1)
+        .itemOutputs(
+            "kubejs:uev_voltage_coil")
+        .duration(400)
+        .EUt(GTValues.VA[GTValues.UHV]);
 
-    sog.recipes.gtceu.autoclave("glow_ink_sac") // sog=event.recipes.gtceu.autoclave(name of the machine)"glow_ink_sak"=recipe id
-      .itemInputs("1x minecraft:ink_sac") // inputs  of the machine
-      .inputFluids(Fluid.of("gtceu:glowstone", 144)) //fl
-      .itemOutputs("1x minecraft:glow_ink_sac")
+    sog.recipes.gtceu.bender("ostrum_plate")
+        .itemInputs(
+            "ad_astra:ostrum_ingot")
+        .itemOutputs(
+            "ad_astra:ostrum_plate")
+        .circuit(1)
+        .duration(40)
+        .EUt(128)
+
+    sog.recipes.gtceu.bender("saturlyte_plate")
+        .itemInputs(
+            "ad_extendra:saturlyte_ingot")
+        .itemOutputs(
+            "ad_extendra:saturlyte_plate")
+        .circuit(1)
+        .duration(40)
+        .EUt(128)
+
+    sog.recipes.gtceu.mixer("mixed_alloy")
+        .itemInputs(
+            "7x gtceu:copper_dust",
+            "4x gtceu:tin_dust",
+            "11x gtceu:iron_dust")
+        .itemOutputs(
+            "22x gtceu:mixed_alloy_dust")
+        .circuit(4)
+        .duration(200)
+        .EUt((GTValues.VA[GTValues.MV]))
+
+    sog.recipes.gtceu.mixer("heavy_duty_alloy_t1")
+        .itemInputs(
+            "16x gtceu:mixed_alloy_dust",
+            "4x gtceu:steel_dust",
+            "11x gtceu:iron_dust")
+        .inputFluids(
+            Fluid.of("gtceu:stainless_steel 144"))
+        .itemOutputs(
+            "gtceu:hot_heavy_duty_alloy_t1_ingot")
+        .circuit(4)
+        .duration(200)
+        .EUt((GTValues.VA[GTValues.HV]))
+
+    sog.recipes.gtceu.mixer("heavy_duty_alloy_t2")
+        .itemInputs(
+            "7x gtceu:platinum_dust",
+            "4x gtceu:osmiridium_dust",
+            "11x gtceu:tantalum_carbide_dust",
+            "gtceu:heavy_duty_alloy_t1_dust")
+        .inputFluids(
+            Fluid.of("gtceu:rhodium_plated_palladium 144"))
+        .itemOutputs(
+            "gtceu:hot_heavy_duty_alloy_t2_ingot")
+        .circuit(4)
+        .duration(200)
+        .EUt((GTValues.VA[GTValues.LuV]))
+
+    sog.recipes.gtceu.mixer("heavy_duty_alloy_t3")
+        .itemInputs(
+            "7x gtceu:ruthenium_trinium_americium_neutronate_dust",
+            "4x gtceu:triplatirium_235_dust",
+            "11x gtceu:atomic_alloy_dust",
+            "gtceu:heavy_duty_alloy_t2_dust")
+        .inputFluids(
+            Fluid.of("gtceu:condensed_star_matter 144"))
+        .itemOutputs(
+            "gtceu:hot_heavy_duty_alloy_t3_ingot")
+        .circuit(4)
+        .duration(200)
+        .EUt((GTValues.VA[GTValues.UHV]))
+
+    sog.recipes.gtceu.implosion_compressor("gtceu:ic/hdat3")
+        .itemInputs(
+            "4x gtceu:industrial_tnt",
+            "gtceu:hot_heavy_duty_alloy_t3_ingot")
+        .itemOutputs(
+            "gtceu:heavy_duty_alloy_t3_ingot")
+        .duration(5)
+        .EUt(GTValues.VA[GTValues.UHV]);
+
+    sog.recipes.gtceu.implosion_compressor("gtceu:ic/hdat2")
+        .itemInputs(
+            "64x minecraft:tnt",
+            "gtceu:hot_heavy_duty_alloy_t2_ingot")
+        .itemOutputs(
+            "gtceu:heavy_duty_alloy_t2_ingot")
+        .duration(5)
+        .EUt(GTValues.VA[GTValues.LuV]);
+
+    sog.recipes.gtceu.implosion_compressor("gtceu:ic/hdat1")
+        .itemInputs(
+            "64x minecraft:tnt",
+            "gtceu:hot_heavy_duty_alloy_t1_ingot")
+        .itemOutputs(
+            "gtceu:heavy_duty_alloy_t1_ingot")
+        .duration(5)
+        .EUt(GTValues.VA[GTValues.LV]);
+
+    sog.recipes.gtceu.implosion_compressor("gtceu:ic/hdat2itnt")
+        .itemInputs(
+            "32x gtceu:industrial_tnt",
+            "gtceu:hot_heavy_duty_alloy_t2_ingot")
+        .itemOutputs(
+            "gtceu:heavy_duty_alloy_t2_ingot")
+        .duration(5)
+        .EUt(GTValues.VA[GTValues.LuV]);
+
+    sog.recipes.gtceu.implosion_compressor("gtceu:ic/hdat1itnt")
+        .itemInputs(
+            "32x gtceu:industrial_tnt",
+            "gtceu:hot_heavy_duty_alloy_t1_ingot")
+        .itemOutputs(
+            "gtceu:heavy_duty_alloy_t1_ingot")
+        .duration(5)
+        .EUt(GTValues.VA[GTValues.LV]);
+
+    sog.recipes.gtceu.autoclave("gtceu:ac/acidic_resonant_residue")
+        .itemInputs(
+            "kubejs:primal_resonant_core")
+        .inputFluids(
+            Fluid.of("gtceu:acidic_venus_residue 144"))
+        .outputFluids(Fluid.of("gtceu:resonant_essence_residue 1000"))
+        .duration(100)
+        .EUt(GTValues.VA[GTValues.UEV]);
+
+    sog.recipes.gtceu.extractor("creative_data2")
+        .itemInputs(
+            "64x #gtceu:circuits/uv")
+        .itemOutputs(
+            "gtceu:creative_data_access_hatch")
+        .duration(100)
+        .EUt(GTValues.VA[GTValues.UV]);
+
+    sog.recipes.gtceu.assembler("kaemite_casing")
+        .itemInputs(
+            "6x gtceu:kaemite_frame",
+            "4x gtceu:kaemite_foil")
+        .inputFluids(
+            "gtceu:polybenzimidazole 63")
+        .circuit(24)
+        .itemOutputs(
+            "2x kubejs:kaemite_casing")
+        .duration(40)
+        .EUt(GTValues.VA[GTValues.UHV]);
+
+    sog.recipes.gtceu.assembler("uevcasing")
+        .itemInputs(
+            "8x gtceu:resonant_essence_plate")
+        .circuit(8)
+        .itemOutputs(
+            "gtceu:uev_machine_casing")
+        .duration(50)
+        .EUt(GTValues.VA[GTValues.LV]);
+
+    sog.recipes.gtceu.large_chemical_reactor("hrcb")
+        .itemInputs(
+            "2x gtceu:wetware_circuit_board",
+            "64x gtceu:antimatter_foil",
+            "kubejs:antimatter_boule")
+        .inputFluids(
+            Fluid.of("gtceu:antimatter", 100))
+        .itemOutputs(
+            "4x kubejs:highly_resonative_circuit_board")
+        .cleanroom(CleanroomType.CLEANROOM)
+        .duration(900)
+        .EUt(GTValues.VA[GTValues.UEV]);
+
+    sog.recipes.gtceu.large_chemical_reactor("hrcb2")
+        .itemInputs(
+            "kubejs:highly_resonative_circuit_board",
+            "32x gtceu:resonant_essence_single_wire")
+        .inputFluids(
+            Fluid.of("gtceu:antimatter", 100))
+        .itemOutputs(
+            "kubejs:highly_resonative_printed_circuit_board")
+        .cleanroom(CleanroomType.CLEANROOM)
+        .duration(1800)
+        .EUt(GTValues.VA[GTValues.UEV]);
+
+    sog.recipes.gtceu.large_chemical_reactor("red_granite")
+        .itemInputs(
+            "minecraft:granite")
+        .inputFluids(
+            Fluid.of("gtceu:redstone", 144))
+        .circuit(8)
+        .itemOutputs(
+            "gtceu:red_granite")
+        .duration(100)
+        .EUt(GTValues.VA[GTValues.EV]);
+
+    sog.recipes.gtceu.autoclave("resonant_matrix")
+        .inputFluids(
+            Fluid.of("gtceu:resonant_naquadah", 144))
+        .itemInputs(
+            "gtceu:crystal_matrix_ingot")
+        .itemOutputs(
+            "avaritia:crystal_matrix_ingot")
+        .duration(20)
+        .EUt((GTValues.VA[GTValues.UHV]))
+
+    sog.recipes.gtceu.mixer("energizedsuperconductor")
+        .circuit(2)
+        .itemInputs(
+            "4x gtceu:gold_dust",
+            "gtceu:coal_dust",
+            "2x minecraft:redstone")
+        .itemOutputs(
+            "3x gtceu:energized_superconductor_dust")
+        .duration(100)
+        .EUt(32)
+
+    sog.recipes.gtceu.mixer("hscsuperconductor")
+        .circuit(4)
+        .itemInputs(
+            "4x gtceu:coal_dust",
+            "4x gtceu:silicon_dust",
+            "2x gtceu:annealed_copper_dust")
+        .inputFluids(
+            "gtceu:oxygen 2000")
+        .itemOutputs(
+            "3x gtceu:hsc_superconductor_dust")
+        .duration(175)
+        .EUt(128)
+
+    sog.recipes.gtceu.mixer("platiumsuperconductor")
+        .circuit(4)
+        .itemInputs(
+            "1x gtceu:coal_dust",
+            "4x gtceu:platinum_dust",
+            "8x gtceu:energium_dust")
+        .itemOutputs(
+            "4x gtceu:platium_superconductor_dust")
+        .duration(275)
+        .EUt(512)
+
+    sog.recipes.gtceu.mixer("tilrunumsuperconductor")
+        .circuit(4)
+        .itemInputs(
+            "1x gtceu:titanium_dust",
+            "4x gtceu:ruthenium_dust",
+            "8x gtceu:molybdenum_dust")
+        .itemOutputs(
+            "13x gtceu:tilrunum_superconductor_dust")
+        .duration(175)
+        .EUt(2048)
+
+    sog.recipes.gtceu.autoclave("crystal_superconductor")
+        .inputFluids(
+            Fluid.of("gtceu:europium", 144))
+        .itemInputs(
+            "gtceu:crystal_soc")
+        .itemOutputs(
+            "4x gtceu:crystal_superconductor_ingot")
+        .duration(380)
+        .EUt((GTValues.VA[GTValues.ZPM]))
+
+    sog.recipes.gtceu.forming_press("cupro_credit")
+        .itemInputs(
+            "gtceu:cupronickel_plate")
+        .notConsumable(
+            "gtceu:cylinder_casting_mold")
+        .itemOutputs(
+            "4x gtmutils:cupronickel_credit")
+        .duration(100)
+        .EUt((GTValues.VA[GTValues.LV]))
+
+    sog.recipes.gtceu.forming_press("moonglobe")
+        .itemInputs(
+            "gtceu:stainless_steel_block")
+        .notConsumable(
+            "ae2:name_press")
+        .notConsumable(
+            "ad_astra:moon_globe")
+        .itemOutputs(
+            "ad_astra:moon_globe")
+        .duration(500)
+        .EUt((GTValues.VA[GTValues.HV]))
+
+    sog.recipes.gtceu.centrifuge("magnaliumbismuth")
+        .itemInputs(
+            "3x gtceu:magnalium_dust")
+        .itemOutputs(
+            "1x gtceu:bismuth_dust")
+        .duration(100)
+        .EUt(32)
+
+    sog.recipes.gtceu.centrifuge("californium")
+        .itemInputs(
+            "3x gtceu:cleaned_californium_dust")
+        .itemOutputs(
+            "1x gtceu:californium_dust")
+        .duration(100)
+        .EUt(32)
+
+    sog.recipes.gtceu.mixer("neutronic_chromite")
+        .circuit(4)
+        .itemInputs(
+            "7x gtceu:chromium_dust",
+            "4x gtceu:neutronium_dust")
+        .itemOutputs(
+            "4x gtceu:neutronic_chromite_dust")
+        .duration(275)
+        .EUt((GTValues.VA[GTValues.UHV]))
+
+    sog.recipes.gtceu.mixer("radium_infused_lead")
+        .circuit(2)
+        .itemInputs(
+            "6x gtceu:lead_dust",
+            "2x gtceu:platinum_dust")
+        .inputFluids(
+            "gtceu:radon 1000")
+        .itemOutputs(
+            "4x gtceu:radium_infused_lead_dust")
+        .duration(275)
+        .EUt((GTValues.VA[GTValues.EV]))
+
+    sog.recipes.gtceu.mixer("stabilized_iridium_dust")
+        .circuit(3)
+        .itemInputs(
+            "19x gtceu:iridium_dust",
+            "4x gtceu:osmium_dust",
+            "8x gtceu:neutronic_chromite_dust",
+            "gtceu:radium_infused_lead_dust")
+        .itemOutputs(
+            "4x gtceu:stabilized_iridium_dust")
+        .duration(275)
+        .EUt((GTValues.VA[GTValues.UHV]))
+
+    sog.recipes.gtceu.mixer("californite")
+        .circuit(4)
+        .itemInputs(
+            "19x gtceu:californium_dust",
+            "8x gtceu:stabilized_iridium_dust")
+        .itemOutputs(
+            "4x gtceu:californite_dust")
+        .duration(275)
+        .EUt((GTValues.VA[GTValues.UEV]))
+
+    sog.recipes.gtceu.mixer("draconium")
+        .circuit(1)
+        .itemInputs(
+            "5x gtceu:hypoxylon_dust",
+            "8x gtceu:stabilized_iridium_dust",
+            "8x gtceu:ruthenium_trinium_americium_neutronate_dust",
+            "2x gtceu:antimatter_dust")
+        .itemOutputs(
+            "4x draconicevolution:draconium_dust")
+        .duration(400)
+        .EUt((GTValues.VA[GTValues.UEV]))
+
+    sog.recipes.gtceu.macerator("shattered")
+        .itemInputs(
+            "advanced_ae:shattered_singularity")
+        .itemOutputs(
+            "advanced_ae:quantum_infused_dust")
+        .duration(15)
+        .EUt(512)
+
+    sog.recipes.gtceu.macerator("refined_apatite_ore_apatite")
+        .itemInputs(
+            "gtceu:refined_apatite_ore")
+        .itemOutputs(
+            "gtceu:apatite_dust")
+        .duration(400)
+        .EUt(2)
+
+    sog.recipes.gtceu.circuit_assembler("quantumprocessor")
+        .itemInputs(
+            "ae2:silicon",
+            "minecraft:redstone",
+            "advanced_ae:quantum_alloy")
+        .inputFluids(
+            "gtceu:lubricant 63")
+        .notConsumable(
+            "ae2:name_press")
+        .itemOutputs(
+            "advanced_ae:quantum_processor")
+        .duration(40)
+        .EUt(2048)
+
+    sog.recipes.gtceu.autoclave("glow_ink_sac")
+      .itemInputs(
+        "1x minecraft:ink_sac")
+      .inputFluids(
+        Fluid.of("gtceu:glowstone", 144))
+      .itemOutputs(
+        "1x minecraft:glow_ink_sac")
       .duration(20 * 5)
       .EUt(16)
 
-sog.shapeless('ae2:interface', ['ae2:cable_interface'])
-sog.shapeless('ae2:pattern_provider', ['ae2:cable_pattern_provider'])
-
-const ebfHeavyAlloyRecipe = (tier, fluidInput, temperature, voltage, durationInSeconds) => {
-    const GAS_BOOST = 0.67
-    const idBase = `heavy_duty_alloy_t${tier}`
-
-    sog.recipes.gtceu.electric_blast_furnace(`blast_${idBase}`)
-        .itemInputs(`gtceu:${idBase}_dust`)
-        .itemOutputs(`gtceu:${idBase}_ingot`)
-        .blastFurnaceTemp(temperature)
-        .duration(20 * durationInSeconds)
-        .circuit(1)
-        .EUt(GTValues.VA[GTValues[voltage]])
-
-    sog.recipes.gtceu.electric_blast_furnace(`blast_${idBase}_gas`)
-        .itemInputs(`gtceu:${idBase}_dust`)
-        .inputFluids(fluidInput)
-        .itemOutputs(`gtceu:${idBase}_ingot`)
-        .blastFurnaceTemp(temperature)
-        .duration(20 * durationInSeconds * GAS_BOOST)
-        .circuit(2)
-        .EUt(GTValues.VA[GTValues[voltage]])
-}
-
-ebfHeavyAlloyRecipe(1, "gtceu:nitrogen 1000", 3500, "HV", 45)
-ebfHeavyAlloyRecipe(2, "gtceu:argon 50", 5100, "LuV", 60)
-ebfHeavyAlloyRecipe(3, "gtceu:krypton 10", 9600, "UHV", 65)
-
-
-sog.recipes.gtceu.assembler('sterile_cleaning_maintenance_hatch')
-    .itemInputs('gtceu:cleaning_maintenance_hatch')
-    .inputFluids(Fluid.of('gtceu:purified_biological_vegtable_goop', 2500))
-    .circuit(9)
-    .itemOutputs('gtmutils:sterile_cleaning_maintenance_hatch')
-    .duration(50)
-    .EUt(GTValues.VA[GTValues.LV]);
-
-sog.recipes.smelting('draconicevolution:draconium_ingot','gtceu:raw_draconium');
-sog.recipes.smelting('draconicevolution:awakened_draconium_ingot','gtceu:raw_awakened_draconium');
-
-sog.recipes.gtceu.electromagnetic_separator('rare_earth')
-    .itemInputs('6x gtceu:rare_earth_dust')
-    .itemOutputs('gtceu:cadmium_dust', 'gtceu:neodymium_dust', 'gtceu:samarium_dust' ,'gtceu:cerium_dust', 'gtceu:yttrium_dust', 'gtceu:lanthanum_dust', 'gtceu:small_europium_dust')
-    .duration(20)
-    .EUt(GTValues.VA[GTValues.UHV]);
-
-    sog.recipes.gtceu.large_chemical_reactor('multilayer_fiber_reinforced_circuit_board_neoprene')
-    .itemInputs('2x gtceu:fiber_reinforced_circuit_board', '8x gtceu:palladium_foil', '4x gtceu:neoprene_foil')
-    .inputFluids('gtceu:sulfuric_acid 500')
-    .itemOutputs('gtceu:multilayer_fiber_reinforced_circuit_board')
-    .cleanroom(CleanroomType.CLEANROOM)
-    .duration(25*20)
-    .EUt(GTValues.VA[GTValues.HV])
-sog.recipes.gtceu.large_chemical_reactor('wetware_printed_circuit_board_xlpe_sp')
-    .itemInputs('gtceu:wetware_circuit_board', '32x gtceu:niobium_titanium_foil', '16x gtceu:xlpe_foil')
-    .inputFluids('gtceu:sodium_persulfate 10000')
-    .itemOutputs('gtceu:wetware_printed_circuit_board')
-    .cleanroom(CleanroomType.CLEANROOM)
-    .duration(25*90)
-    .EUt(GTValues.VA[GTValues.HV]);
-sog.recipes.gtceu.large_chemical_reactor('wetware_printed_circuit_board_xlpe_ic')
-    .itemInputs('gtceu:wetware_circuit_board', '32x gtceu:niobium_titanium_foil', '16x gtceu:xlpe_foil')
-    .inputFluids('gtceu:iron_iii_chloride 5000')
-    .itemOutputs('gtceu:wetware_printed_circuit_board')
-    .cleanroom(CleanroomType.CLEANROOM)
-    .duration(25*90)
-    .EUt(GTValues.VA[GTValues.HV]);
-
-sog.recipes.gtceu.alloy_smelter('netherite')
-    .itemInputs('4x minecraft:netherite_scrap', '4x minecraft:gold_ingot')
-    .itemOutputs('minecraft:netherite_ingot')
-    .duration(20*5)
-    .EUt(GTValues.VA[GTValues.HV]);
-
-sog.replaceInput( {id: 'gtceu:assembly_line/electric_pump_uv'}, 'gtceu:silicone_rubber_ring', 'gtceu:neoprene_ring' )
-sog.replaceInput( {id: 'gtceu:assembly_line/conveyor_module_uv'}, 'gtceu:styrene_butadiene_rubber', 'gtceu:neoprene' )
-
-sog.recipes.gtceu.mixer('gregification_crystaltine')
-    .itemInputs(
-        '4x gtceu:iron_dust',
-        '10x gtceu:lapis_dust',
-        '2x gtceu:nether_star_dust',
-        '8x gtceu:diamond_dust',
-        '4x gtceu:gold_dust')
-    .itemOutputs('4x extendedcrafting:crystaltine_ingot')
-    .duration(10*20)
-    .EUt(GTValues.VA[GTValues.UHV])
-
-sog.recipes.gtceu.forming_press('neutronium_drill_head')
-    .itemInputs('4x gtceu:neutronium_plate', '4x gtceu:steel_plate')
-    .itemOutputs('gtceu:neutronium_drill_head')
-    .duration(20*5)
-    .EUt(GTValues.VA[GTValues.UHV])
-
-sog.recipes.gtceu.assembler('blazing_cleaning_maintenance_hatch')
-    .itemInputs("gtmutils:sterile_cleaning_maintenance_hatch", "4x gtceu:uiv_robot_arm", "2x gtceu:uiv_electric_pump", "16x gtceu:pure_cosmic_matter_spring")
-    .inputFluids("gtceu:blaze 3500")
-    .itemOutputs('phoenix_gregic_additons:blazing_cleaning_maintenance_hatch')
-    .duration(20*60)
-    .EUt(GTValues.VA[GTValues.UIV]);
-
-sog.recipes.gtceu.chemical_reactor('better_calcium_chloride')
-    .itemInputs('3x gtceu:calcium_dust')
-	.inputFluids('gtceu:chlorine 2000')
-	.itemOutputs('6x gtceu:calcium_chloride_dust')
-	.duration(20*30)
-	.EUt((GTValues.VA[GTValues.HV]))
-
-    sog.recipes.gtceu.assembler('draconium_hypoxyloninfused_antimatter_casing')
+    sog.recipes.gtceu.assembler("sterile_cleaning_maintenance_hatch")
         .itemInputs(
-            'gtceu:atomic_casing',
-            '4x gtceu:dense_draconium_plate',
-            '4x gtceu:dense_hypoxylon_plate'
-        )
-        .inputFluids('gtceu:antimatter 10000')
-        .itemOutputs('phoenix_gregic_additons:space_time_cooled_eternity_casing')
-        .duration(100)
-        .EUt(GTValues.VA[GTValues.UEV])
-    sog.recipes.gtceu.assembler('akashic_computation_casing')
+            "gtceu:cleaning_maintenance_hatch")
+        .inputFluids(
+            Fluid.of("gtceu:purified_biological_vegtable_goop", 2500))
+        .circuit(9)
+        .itemOutputs(
+            "gtmutils:sterile_cleaning_maintenance_hatch")
+        .duration(50)
+        .EUt(GTValues.VA[GTValues.LV]);
+
+    sog.recipes.smelting(
+        "draconicevolution:draconium_ingot",
+        "gtceu:raw_draconium");
+
+    sog.recipes.smelting(
+        "draconicevolution:awakened_draconium_ingot",
+        "gtceu:raw_awakened_draconium");
+
+    sog.recipes.gtceu.electromagnetic_separator("rare_earth")
         .itemInputs(
-            'phoenix_gregic_additons:space_time_cooled_eternity_casing',
-            '9x gtceu:dense_draconium_plate',
-            '16x gtceu:hypoxylon_foil'
-        )
-        .inputFluids('gtceu:antimatter 10000')
-        .itemOutputs('phoenix_gregic_additons:akashic_zeronium_casing')
-        .duration(100)
-        .EUt(GTValues.VA[GTValues.UEV])
-    sog.recipes.gtceu.assembler('perfected_logic_casing')
+            "6x gtceu:rare_earth_dust")
+        .itemOutputs(
+            "gtceu:cadmium_dust",
+            "gtceu:neodymium_dust",
+            "gtceu:samarium_dust" ,"gtceu:cerium_dust",
+            "gtceu:yttrium_dust",
+            "gtceu:lanthanum_dust",
+            "gtceu:small_europium_dust")
+        .duration(20)
+        .EUt(GTValues.VA[GTValues.UHV]);
+
+    sog.recipes.gtceu.large_chemical_reactor("multilayer_fiber_reinforced_circuit_board_neoprene")
         .itemInputs(
-            '8x #gtceu:circuits/uev',
-            'phoenix_gregic_additons:akashic_zeronium_casing'
-        )
-        .inputFluids('gtceu:antimatter 10000')
-        .itemOutputs('phoenix_gregic_additons:perfected_logic')
-        .duration(100)
-        .EUt(GTValues.VA[GTValues.UEV])
-    sog.recipes.gtceu.assembler('computation_coil')
+            "2x gtceu:fiber_reinforced_circuit_board",
+            "8x gtceu:palladium_foil",
+            "4x gtceu:neoprene_foil")
+        .inputFluids(
+            "gtceu:sulfuric_acid 500")
+        .itemOutputs(
+            "gtceu:multilayer_fiber_reinforced_circuit_board")
+        .cleanroom(CleanroomType.CLEANROOM)
+        .duration(25*20)
+        .EUt(GTValues.VA[GTValues.HV])
+
+    sog.recipes.gtceu.large_chemical_reactor("wetware_printed_circuit_board_xlpe_sp")
         .itemInputs(
-            'kubejs:resonant_essence_coil_block',
-            'phoenix_gregic_additons:space_time_cooled_eternity_casing'
-        )
-        .inputFluids('gtceu:antimatter 2500')
-        .itemOutputs('phoenix_gregic_additons:akashic_coil_block')
+            "gtceu:wetware_circuit_board",
+            "32x gtceu:niobium_titanium_foil",
+            "16x gtceu:xlpe_foil")
+        .inputFluids(
+            "gtceu:sodium_persulfate 10000")
+        .itemOutputs(
+            "gtceu:wetware_printed_circuit_board")
+        .cleanroom(CleanroomType.CLEANROOM)
+        .duration(25*90)
+        .EUt(GTValues.VA[GTValues.HV]);
+
+    sog.recipes.gtceu.large_chemical_reactor("wetware_printed_circuit_board_xlpe_ic")
+        .itemInputs(
+            "gtceu:wetware_circuit_board",
+            "32x gtceu:niobium_titanium_foil",
+            "16x gtceu:xlpe_foil")
+        .inputFluids(
+            "gtceu:iron_iii_chloride 5000")
+        .itemOutputs(
+            "gtceu:wetware_printed_circuit_board")
+        .cleanroom(CleanroomType.CLEANROOM)
+        .duration(25*90)
+        .EUt(GTValues.VA[GTValues.HV]);
+
+    sog.recipes.gtceu.alloy_smelter("netherite")
+        .itemInputs(
+            "4x minecraft:netherite_scrap",
+            "4x minecraft:gold_ingot")
+        .itemOutputs(
+            "minecraft:netherite_ingot")
+        .duration(20*5)
+        .EUt(GTValues.VA[GTValues.HV]);
+
+    sog.recipes.gtceu.mixer("gregification_crystaltine")
+        .itemInputs(
+            "4x gtceu:iron_dust",
+            "10x gtceu:lapis_dust",
+            "2x gtceu:nether_star_dust",
+            "8x gtceu:diamond_dust",
+            "4x gtceu:gold_dust")
+        .itemOutputs(
+            "4x extendedcrafting:crystaltine_ingot")
+        .duration(10*20)
+        .EUt(GTValues.VA[GTValues.UHV])
+
+    sog.recipes.gtceu.forming_press("neutronium_drill_head")
+        .itemInputs(
+            "4x gtceu:neutronium_plate",
+            "4x gtceu:steel_plate")
+        .itemOutputs(
+            "gtceu:neutronium_drill_head")
+        .duration(20*5)
+        .EUt(GTValues.VA[GTValues.UHV])
+
+    sog.recipes.gtceu.assembler("blazing_cleaning_maintenance_hatch")
+        .itemInputs(
+            "gtmutils:sterile_cleaning_maintenance_hatch",
+            "4x gtceu:uiv_robot_arm",
+            "2x gtceu:uiv_electric_pump",
+            "16x gtceu:pure_cosmic_matter_spring")
+        .inputFluids(
+            "gtceu:blaze 3500")
+        .itemOutputs(
+            "phoenix_gregic_additons:blazing_cleaning_maintenance_hatch")
+        .duration(20*60)
+        .EUt(GTValues.VA[GTValues.UIV]);
+
+    sog.recipes.gtceu.chemical_reactor("better_calcium_chloride")
+        .itemInputs(
+            "3x gtceu:calcium_dust")
+	    .inputFluids(
+            "gtceu:chlorine 2000")
+	    .itemOutputs(
+            "6x gtceu:calcium_chloride_dust")
+	    .duration(20*30)
+	    .EUt((GTValues.VA[GTValues.HV]))
+
+    sog.recipes.gtceu.assembler("draconium_hypoxyloninfused_antimatter_casing")
+        .itemInputs(
+            "gtceu:atomic_casing",
+            "4x gtceu:dense_draconium_plate",
+            "4x gtceu:dense_hypoxylon_plate")
+        .inputFluids(
+            "gtceu:antimatter 10000")
+        .itemOutputs(
+            "phoenix_gregic_additons:space_time_cooled_eternity_casing")
         .duration(100)
         .EUt(GTValues.VA[GTValues.UEV])
 
-    sog.recipes.gtceu.assembler('phoenix_computer_casing')
+    sog.recipes.gtceu.assembler("akashic_computation_casing")
         .itemInputs(
-            'gtceu:computer_casing'
-        )
-        .inputFluids('gtceu:antimatter 2500')
-        .itemOutputs('phoenix_gregic_additons:phoenix_computer_casing')
-        .duration(100)
-        .EUt(GTValues.VA[GTValues.UEV])
-    sog.recipes.gtceu.assembler('advanced_phoenix_computer_casing')
-        .itemInputs(
-            'gtceu:advanced_computer_casing'
-        )
-        .inputFluids('gtceu:antimatter 2500')
-        .itemOutputs('phoenix_gregic_additons:phoenix_advanced_computer_casing')
-        .duration(100)
-        .EUt(GTValues.VA[GTValues.UEV])
-    sog.recipes.gtceu.assembler('phoenix_computer_heat_vent')
-        .itemInputs(
-            'gtceu:computer_heat_vent'
-        )
-        .inputFluids('gtceu:antimatter 2500')
-        .itemOutputs('phoenix_gregic_additons:phoenix_computer_heat_vent')
+            "phoenix_gregic_additons:space_time_cooled_eternity_casing",
+            "9x gtceu:dense_draconium_plate",
+            "16x gtceu:hypoxylon_foil")
+        .inputFluids(
+            "gtceu:antimatter 10000")
+        .itemOutputs(
+            "phoenix_gregic_additons:akashic_zeronium_casing")
         .duration(100)
         .EUt(GTValues.VA[GTValues.UEV])
 
-    sog.recipes.gtceu.assembler('phoenix_computation_component')
+    sog.recipes.gtceu.assembler("perfected_logic_casing")
         .itemInputs(
-            'gtceu:hpca_advanced_computation_component',
-            '4x #gtceu:circuits/uhv',
-            'gtceu:uv_field_generator',
-        )
-        .inputFluids('gtceu:pcb_coolant 10000')
-        .itemOutputs('phoenix_gregic_additons:phoenix_computation_component')
+            "8x #gtceu:circuits/uev",
+            "phoenix_gregic_additons:akashic_zeronium_casing")
+        .inputFluids(
+            "gtceu:antimatter 10000")
+        .itemOutputs(
+            "phoenix_gregic_additons:perfected_logic")
+        .duration(100)
+        .EUt(GTValues.VA[GTValues.UEV])
+
+    sog.recipes.gtceu.assembler("computation_coil")
+        .itemInputs(
+            "kubejs:resonant_essence_coil_block",
+            "phoenix_gregic_additons:space_time_cooled_eternity_casing")
+        .inputFluids(
+            "gtceu:antimatter 2500")
+        .itemOutputs(
+            "phoenix_gregic_additons:akashic_coil_block")
+        .duration(100)
+        .EUt(GTValues.VA[GTValues.UEV])
+
+    sog.recipes.gtceu.assembler("phoenix_computer_casing")
+        .itemInputs(
+            "gtceu:computer_casing")
+        .inputFluids(
+            "gtceu:antimatter 2500")
+        .itemOutputs(
+            "phoenix_gregic_additons:phoenix_computer_casing")
+        .duration(100)
+        .EUt(GTValues.VA[GTValues.UEV])
+
+    sog.recipes.gtceu.assembler("advanced_phoenix_computer_casing")
+        .itemInputs(
+            "gtceu:advanced_computer_casing")
+        .inputFluids(
+            "gtceu:antimatter 2500")
+        .itemOutputs(
+            "phoenix_gregic_additons:phoenix_advanced_computer_casing")
+        .duration(100)
+        .EUt(GTValues.VA[GTValues.UEV])
+
+    sog.recipes.gtceu.assembler("phoenix_computer_heat_vent")
+        .itemInputs(
+            "gtceu:computer_heat_vent")
+        .inputFluids(
+            "gtceu:antimatter 2500")
+        .itemOutputs(
+            "phoenix_gregic_additons:phoenix_computer_heat_vent")
+        .duration(100)
+        .EUt(GTValues.VA[GTValues.UEV])
+
+    sog.recipes.gtceu.assembler("phoenix_computation_component")
+        .itemInputs(
+            "gtceu:hpca_advanced_computation_component",
+            "4x #gtceu:circuits/uhv",
+            "gtceu:uv_field_generator")
+        .inputFluids(
+            "gtceu:pcb_coolant 10000")
+        .itemOutputs(
+            "phoenix_gregic_additons:phoenix_computation_component")
         .duration(1200)
         .cleanroom(CleanroomType.CLEANROOM)
         .EUt(GTValues.VA[GTValues.UHV])
-    sog.recipes.gtceu.assembler('advanced_phoenix_computation_component')
+
+    sog.recipes.gtceu.assembler("advanced_phoenix_computation_component")
         .itemInputs(
-            'phoenix_gregic_additons:phoenix_computation_component',
-            '4x #gtceu:circuits/uev',
-            'gtceu:uhv_field_generator',
-        )
-        .inputFluids('gtceu:pcb_coolant 10000')
-        .itemOutputs('phoenix_gregic_additons:advanced_phoenix_computation_component')
+            "phoenix_gregic_additons:phoenix_computation_component",
+            "4x #gtceu:circuits/uev",
+            "gtceu:uhv_field_generator")
+        .inputFluids(
+            "gtceu:pcb_coolant 10000")
+        .itemOutputs(
+            "phoenix_gregic_additons:advanced_phoenix_computation_component")
         .duration(1200)
         .cleanroom(CleanroomType.CLEANROOM)
         .EUt(GTValues.VA[GTValues.UEV])
 
     sog.recipes.gtceu.hgim("bettercondensedstarmatter")
         .itemInputs(
-            "8x gtceu:silicone_rubber_plate"
-        )
+            "8x gtceu:silicone_rubber_plate")
         .inputFluids(
             "gtceu:star_matter 20736",
-            "gtceu:sodium_potassium 12000"
-        )
+            "gtceu:sodium_potassium 12000")
         .itemOutputs(
-            "kubejs:condensed_star_matter"
-        )
+            "kubejs:condensed_star_matter")
         .EUt(GTValues.VA[GTValues.UEV])
         .duration(20 * 25)
 
-    sog.recipes.gtceu.mixer('mixed_quantum_infused_dust')
-        .itemInputs('advanced_ae:quantum_infused_dust')
-        .inputFluids('minecraft:water 1000')
-        .outputFluids('advanced_ae:quantum_infusion_source 1000')
+    sog.recipes.gtceu.mixer("mixed_quantum_infused_dust")
+        .itemInputs(
+            "advanced_ae:quantum_infused_dust")
+        .inputFluids(
+            "minecraft:water 1000")
+        .outputFluids(
+            "advanced_ae:quantum_infusion_source 1000")
         .duration(20 * 10)
         .EUt(GTValues.VA[GTValues.HV])
 
-    sog.recipes.gtceu.mixer('mixed_shattered_singularity')
-        .itemInputs('ae2:singularity','2x ae2:sky_dust','2x #forge:dusts/ender_pearl')
-        .inputFluids('minecraft:lava 100')
-        .itemOutputs('2x advanced_ae:shattered_singularity')
+    sog.recipes.gtceu.mixer("mixed_shattered_singularity")
+        .itemInputs(
+            "ae2:singularity",
+            "2x ae2:sky_dust",
+            "2x #forge:dusts/ender_pearl")
+        .inputFluids(
+            "minecraft:lava 100")
+        .itemOutputs(
+            "2x advanced_ae:shattered_singularity")
         .duration(20 * 10)
         .EUt(GTValues.VA[GTValues.HV])
 
-    sog.recipes.gtceu.mixer('mixed_quantum_alloy')
-        .itemInputs('4x gtceu:copper_dust','4x advanced_ae:shattered_singularity','4x ae2:singularity')
-        .inputFluids('advanced_ae:quantum_infusion_source 1000')
-        .itemOutputs('4x advanced_ae:quantum_alloy') 
+    sog.recipes.gtceu.mixer("mixed_quantum_alloy")
+        .itemInputs(
+            "4x gtceu:copper_dust",
+            "4x advanced_ae:shattered_singularity",
+            "4x ae2:singularity")
+        .inputFluids(
+            "advanced_ae:quantum_infusion_source 1000")
+        .itemOutputs(
+            "4x advanced_ae:quantum_alloy") 
         .duration(20 * 10)
         .EUt(GTValues.VA[GTValues.HV])
 
-    sog.recipes.gtceu.mixer('mixed_quantum_alloy_plate')
-        .itemInputs('8x advanced_ae:quantum_alloy','2x minecraft:netherite_ingot','minecraft:nether_star')
-        .inputFluids('advanced_ae:quantum_infusion_source 1000')
-        .itemOutputs('advanced_ae:quantum_alloy_plate') 
+    sog.recipes.gtceu.mixer("mixed_quantum_alloy_plate")
+        .itemInputs(
+            "8x advanced_ae:quantum_alloy",
+            "2x minecraft:netherite_ingot",
+            "minecraft:nether_star")
+        .inputFluids(
+            "advanced_ae:quantum_infusion_source 1000")
+        .itemOutputs(
+            "advanced_ae:quantum_alloy_plate") 
         .duration(20 * 10)  
         .EUt(GTValues.VA[GTValues.HV]) 
 
-
-    sog.recipes.gtceu.assembler('draconium_assembly_line')
+    sog.recipes.gtceu.assembler("draconium_assembly_line")
         .itemInputs(
-            'gtceu:dense_draconium_plate',
-            '#gtceu:circuits/uiv',
-            'gtceu:dense_draconium_plate',
-            'gtceu:circuit_assembly_line',
-            'gtceu:assembly_line',
-            'gtceu:component_assembly_line',
-            'gtceu:dense_draconium_plate',
-            '#gtceu:circuits/uiv',
-            'gtceu:dense_draconium_plate'
+            "gtceu:dense_draconium_plate",
+            "#gtceu:circuits/uiv",
+            "gtceu:dense_draconium_plate",
+            "gtceu:circuit_assembly_line",
+            "gtceu:assembly_line",
+            "gtceu:component_assembly_line",
+            "gtceu:dense_draconium_plate",
+            "#gtceu:circuits/uiv",
+            "gtceu:dense_draconium_plate"
         )
-        .inputFluids('gtceu:draconium 9216')
-        .itemOutputs('gtceu:draconium_assembly_line')
+        .inputFluids(
+            "gtceu:draconium 9216")
+        .itemOutputs(
+            "gtceu:draconium_assembly_line")
         .duration(20*1200)
         .EUt(GTValues.VA[GTValues.UIV])
-	
-    sog.recipes.gtceu.assembler('eternity_assembly_control_casing')
+
+    sog.recipes.gtceu.assembler("eternity_assembly_control_casing")
         .itemInputs(
-            'gtceu:eternity_plate',
-            'gtceu:eternity_plate',
-            'gtceu:eternity_plate',
-            'gtceu:eternity_plate',
-            '64x gtceu:assembly_line_unit',
-            'gtceu:eternity_plate',
-            'gtceu:eternity_plate',
-            'gtceu:eternity_plate',
-            'gtceu:eternity_plate'
-        )
-        .inputFluids('gtceu:eternity 144')
-        .itemOutputs('kubejs:eternity_assembly_control_casing')
+            "gtceu:eternity_plate",
+            "gtceu:eternity_plate",
+            "gtceu:eternity_plate",
+            "gtceu:eternity_plate",
+            "64x gtceu:assembly_line_unit",
+            "gtceu:eternity_plate",
+            "gtceu:eternity_plate",
+            "gtceu:eternity_plate",
+            "gtceu:eternity_plate")
+        .inputFluids(
+            "gtceu:eternity 144")
+        .itemOutputs(
+            "kubejs:eternity_assembly_control_casing")
+        .duration(20*60)
+        .EUt(GTValues.VA[GTValues.UIV])	
+
+    sog.recipes.gtceu.assembler("draconic_assembly_control_casing")
+        .itemInputs(
+            "gtceu:dense_draconium_plate",
+            "gtceu:dense_draconium_plate",
+            "gtceu:dense_draconium_plate",
+            "gtceu:dense_draconium_plate",
+            "64x gtceu:assembly_line_unit",
+            "gtceu:dense_draconium_plate",
+            "gtceu:dense_draconium_plate",
+            "gtceu:dense_draconium_plate",
+            "gtceu:dense_draconium_plate")
+        .inputFluids(
+            "gtceu:draconium 9216")
+        .itemOutputs(
+            "kubejs:draconic_assembly_control_casing")
         .duration(20*60)
         .EUt(GTValues.VA[GTValues.UIV])
-	
-    sog.recipes.gtceu.assembler('draconic_assembly_control_casing')
+
+    sog.recipes.gtceu.assembler("draconic_assembly_line_casing")
         .itemInputs(
-            'gtceu:dense_draconium_plate',
-            'gtceu:dense_draconium_plate',
-            'gtceu:dense_draconium_plate',
-            'gtceu:dense_draconium_plate',
-            '64x gtceu:assembly_line_unit',
-            'gtceu:dense_draconium_plate',
-            'gtceu:dense_draconium_plate',
-            'gtceu:dense_draconium_plate',
-            'gtceu:dense_draconium_plate'
-        )
-        .inputFluids('gtceu:draconium 9216')
-        .itemOutputs('kubejs:draconic_assembly_control_casing')
-        .duration(20*60)
-        .EUt(GTValues.VA[GTValues.UIV])
-	
-    sog.recipes.gtceu.assembler('draconic_assembly_line_casing')
-        .itemInputs(
-            'gtceu:dense_draconium_plate',
-            'gtceu:dense_draconium_plate',
-            'gtceu:dense_draconium_plate',
-            'gtceu:dense_draconium_plate',
-            '64x gtceu:assembly_line_casing',
-            'gtceu:dense_draconium_plate',
-            'gtceu:dense_draconium_plate',
-            'gtceu:dense_draconium_plate',
-            'gtceu:dense_draconium_plate'
-        )
-        .inputFluids('gtceu:draconium 9216')
-        .itemOutputs('kubejs:draconic_assembly_line_casing')
+            "gtceu:dense_draconium_plate",
+            "gtceu:dense_draconium_plate",
+            "gtceu:dense_draconium_plate",
+            "gtceu:dense_draconium_plate",
+            "64x gtceu:assembly_line_casing",
+            "gtceu:dense_draconium_plate",
+            "gtceu:dense_draconium_plate",
+            "gtceu:dense_draconium_plate",
+            "gtceu:dense_draconium_plate")
+        .inputFluids(
+            "gtceu:draconium 9216")
+        .itemOutputs(
+            "kubejs:draconic_assembly_line_casing")
         .duration(1200)
         .EUt(GTValues.VA[GTValues.UIV])
-	
-    sog.recipes.gtceu.assembler('draconium_machine_casing')
+
+    sog.recipes.gtceu.assembler("draconium_machine_casing")
         .itemInputs(
-            '6x gtceu:draconium_plate',
-            'gtceu:draconium_frame'
-        )
+            "6x gtceu:draconium_plate",
+            "gtceu:draconium_frame")
         .circuit(6)
-        .itemOutputs('kubejs:draconium_machine_casing')
+        .itemOutputs(
+            "kubejs:draconium_machine_casing")
         .duration(20*60)
-        .EUt(GTValues.VA[GTValues.UIV])
-	
-    sog.recipes.gtceu.assembler('draconium_assembly_line_grating')
+        .EUt(GTValues.VA[GTValues.UIV])	
+
+    sog.recipes.gtceu.assembler("draconium_assembly_line_grating")
         .itemInputs(
-            'gtceu:dense_draconium_plate',
-            'gtceu:dense_draconium_plate',
-            'gtceu:dense_draconium_plate',
-            'gtceu:dense_draconium_plate',
-            '64x gtceu:assembly_line_grating',
-            'gtceu:dense_draconium_plate',
-            'gtceu:dense_draconium_plate',
-            'gtceu:dense_draconium_plate',
-            'gtceu:dense_draconium_plate'
-        )
-        .inputFluids('gtceu:draconium 9216')
-        .itemOutputs('kubejs:draconic_assembly_line_grating')
+            "gtceu:dense_draconium_plate",
+            "gtceu:dense_draconium_plate",
+            "gtceu:dense_draconium_plate",
+            "gtceu:dense_draconium_plate",
+            "64x gtceu:assembly_line_grating",
+            "gtceu:dense_draconium_plate",
+            "gtceu:dense_draconium_plate",
+            "gtceu:dense_draconium_plate",
+            "gtceu:dense_draconium_plate")
+        .inputFluids(
+            "gtceu:draconium 9216")
+        .itemOutputs(
+            "kubejs:draconic_assembly_line_grating")
         .duration(20*60)
         .EUt(GTValues.VA[GTValues.UIV])
 
-sog.recipes.gtceu.assembler('covalent_conducting_casing')
+    sog.recipes.gtceu.assembler("covalent_conducting_casing")
         .itemInputs(
-            'gtceu:pure_cosmic_matter_plate',
-            'gtceu:pure_cosmic_matter_plate',
-            'gtceu:pure_cosmic_matter_plate',
-            'gtceu:pure_cosmic_matter_plate',
-            '64x gtceu:nonconducting_casing',
-            'gtceu:pure_cosmic_matter_plate',
-            'gtceu:pure_cosmic_matter_plate',
-            'gtceu:pure_cosmic_matter_plate',
-            'gtceu:pure_cosmic_matter_plate'
-        )
-        .inputFluids('gtceu:eternity 100')
-        .itemOutputs('kubejs:covalent_conducting_casing')
-        .duration(20*45)
-        .EUt(GTValues.VA[GTValues.UXV])
-    sog.recipes.gtceu.assembler('refracting_hastelloy_c276_casing')
-        .itemInputs(
-            '16x gtceu:tritanium_coil_block',
-            '16x gtceu:tritanium_coil_block',
-            '16x gtceu:tritanium_coil_block',
-            '16x gtceu:tritanium_coil_block',
-            '64x gtceu:hastelloy_c_276_block',
-            '16x gtceu:tritanium_coil_block',
-            '16x gtceu:tritanium_coil_block',
-            '16x gtceu:tritanium_coil_block',
-            '16x gtceu:tritanium_coil_block'
-        )
-        .inputFluids('gtceu:hastelloy_c_276 9216')
-        .itemOutputs('kubejs:refracting_hastelloy_c276_casing')
-        .duration(20*45)
-        .EUt(GTValues.VA[GTValues.UXV])
-    sog.recipes.gtceu.assembler('temperature_proof_potin_casing')
-        .itemInputs(
-            '64x gtceu:double_rose_gold_plate',
-            '64x gtceu:double_rose_gold_plate',
-            '64x gtceu:double_rose_gold_plate',
-            '64x gtceu:double_rose_gold_plate',
-            '64x gtceu:potin_block',
-            '64x gtceu:double_rose_gold_plate',
-            '64x gtceu:double_rose_gold_plate',
-            '64x gtceu:double_rose_gold_plate',
-            '64x gtceu:double_rose_gold_plate'
-        )
-        .inputFluids('gtceu:potin 92160')
-        .itemOutputs('2x kubejs:temperature_proof_potin_casing')
-        .duration(20*45)
-        .EUt(GTValues.VA[GTValues.UXV])
-    sog.recipes.gtceu.assembler('reinforced_base_casing')
-        .itemInputs(
-            'gtceu:dense_cosmic_neutronium_plate',
-            'gtceu:pure_cosmic_matter_plate',
-            'gtceu:dense_cosmic_neutronium_plate',
-            'gtceu:pure_cosmic_matter_plate',
-            'kubejs:highly_reinforced_radioactive_casing',
-            'gtceu:pure_cosmic_matter_plate',
-            'gtceu:dense_cosmic_neutronium_plate',
-            'gtceu:pure_cosmic_matter_plate',
-            'gtceu:dense_cosmic_neutronium_plate'
-        )
-        .inputFluids('gtceu:concrete 1000000')
-        .itemOutputs('kubejs:reinforced_base_casing')
-        .duration(20*45)
-        .EUt(GTValues.VA[GTValues.UXV])
-    sog.recipes.gtceu.assembler('supercritical_cryo_cooled_casing')
-        .itemInputs(
-            'gtceu:double_blue_steel_plate',
-            'gtceu:pure_cosmic_matter_plate',
-            'gtceu:double_blue_steel_plate',
-            'gtceu:pure_cosmic_matter_plate',
-            'kubejs:cryogenic_casing',
-            'gtceu:pure_cosmic_matter_plate',
-            'gtceu:double_blue_steel_plate',
-            'gtceu:pure_cosmic_matter_plate',
-            'gtceu:double_blue_steel_plate'
-        )
-        .inputFluids('gtceu:cryogenic_neutron_flow 10000')
-        .itemOutputs('kubejs:supercritical_cryo_cooled_casing')
-        .duration(20*45)
-        .EUt(GTValues.VA[GTValues.UXV])
-    sog.recipes.gtceu.assembly_line('mega_oreproc_facility')
-        .itemInputs(
-            'gtceu:uxv_macerator',
-            'gtceu:uxv_electrolyzer',
-            'gtceu:uxv_centrifuge',
-            'gtceu:uxv_sifter',
-            '16x kubejs:reinforced_base_casing',
-            '64x kubejs:adv_high_power_crushing_wheels',
-            '64x kubejs:adv_high_power_crushing_wheels',
-            '16x kubejs:reinforced_base_casing',
-            '16x kubejs:reinforced_base_casing',
-            '64x gtceu:adv_processing_plant',
-            '64x gtceu:adv_processing_plant',
-            '16x kubejs:reinforced_base_casing',
-            '16x kubejs:reinforced_base_casing',
-            'gtceu:uxv_conveyor_module',
-            'gtceu:uxv_conveyor_module',
-            '16x kubejs:reinforced_base_casing'
-        )
+            "gtceu:pure_cosmic_matter_plate",
+            "gtceu:pure_cosmic_matter_plate",
+            "gtceu:pure_cosmic_matter_plate",
+            "gtceu:pure_cosmic_matter_plate",
+            "64x gtceu:nonconducting_casing",
+            "gtceu:pure_cosmic_matter_plate",
+            "gtceu:pure_cosmic_matter_plate",
+            "gtceu:pure_cosmic_matter_plate",
+            "gtceu:pure_cosmic_matter_plate")
         .inputFluids(
-            'gtceu:meta_stable_molten_kevlar 2500',
-            'gtceu:cosmic_matter 5000',
-            'gtceu:eternity 10000',
-            'gtceu:hypoxylon 20000'
-        )
-        .itemOutputs('gtceu:mega_oreproc_facility')
-        .duration(20*1200)
+            "gtceu:eternity 100")
+        .itemOutputs(
+            "kubejs:covalent_conducting_casing")
+        .duration(20*45)
         .EUt(GTValues.VA[GTValues.UXV])
-    sog.recipes.gtceu.assembly_line('distillation_facility_complex')
+
+    sog.recipes.gtceu.assembler("refracting_hastelloy_c276_casing")
         .itemInputs(
-            'gtceu:uxv_distillery',
-            '64x gtceu:extreme_cracking_unit',
-            '64x gtceu:extreme_cracking_unit',
-            'gtceu:uxv_distillery',
-            '16x kubejs:reinforced_base_casing',
-            '64x gtceu:chemical_plant',
-            '64x gtceu:chemical_plant',
-            '16x kubejs:reinforced_base_casing',
-            '16x kubejs:reinforced_base_casing',
-            '4x kubejs:advanced_air_intake_hatch',
-            '4x kubejs:advanced_air_intake_hatch',
-            '16x kubejs:reinforced_base_casing',
-            '16x kubejs:reinforced_base_casing',
-            'gtceu:uxv_electric_pump',
-            'gtceu:uxv_electric_pump',
-            '16x kubejs:reinforced_base_casing'
-        )
+            "16x gtceu:tritanium_coil_block",
+            "16x gtceu:tritanium_coil_block",
+            "16x gtceu:tritanium_coil_block",
+            "16x gtceu:tritanium_coil_block",
+            "64x gtceu:hastelloy_c_276_block",
+            "16x gtceu:tritanium_coil_block",
+            "16x gtceu:tritanium_coil_block",
+            "16x gtceu:tritanium_coil_block",
+            "16x gtceu:tritanium_coil_block")
         .inputFluids(
-            'gtceu:meta_stable_molten_kevlar 2500',
-            'gtceu:cosmic_matter 5000',
-            'gtceu:eternity 10000',
-            'gtceu:hypoxylon 20000'
-        )
-        .itemOutputs('gtceu:distillation_facility_complex')
+            "gtceu:hastelloy_c_276 9216")
+        .itemOutputs(
+            "kubejs:refracting_hastelloy_c276_casing")
+        .duration(20*45)
+        .EUt(GTValues.VA[GTValues.UXV])
+
+    sog.recipes.gtceu.assembler("temperature_proof_potin_casing")
+        .itemInputs(
+            "64x gtceu:double_rose_gold_plate",
+            "64x gtceu:double_rose_gold_plate",
+            "64x gtceu:double_rose_gold_plate",
+            "64x gtceu:double_rose_gold_plate",
+            "64x gtceu:potin_block",
+            "64x gtceu:double_rose_gold_plate",
+            "64x gtceu:double_rose_gold_plate",
+            "64x gtceu:double_rose_gold_plate",
+            "64x gtceu:double_rose_gold_plate")
+        .inputFluids(
+            "gtceu:potin 92160")
+        .itemOutputs(
+            "2x kubejs:temperature_proof_potin_casing")
+        .duration(20*45)
+        .EUt(GTValues.VA[GTValues.UXV])
+
+    sog.recipes.gtceu.assembler("reinforced_base_casing")
+        .itemInputs(
+            "gtceu:dense_cosmic_neutronium_plate",
+            "gtceu:pure_cosmic_matter_plate",
+            "gtceu:dense_cosmic_neutronium_plate",
+            "gtceu:pure_cosmic_matter_plate",
+            "kubejs:highly_reinforced_radioactive_casing",
+            "gtceu:pure_cosmic_matter_plate",
+            "gtceu:dense_cosmic_neutronium_plate",
+            "gtceu:pure_cosmic_matter_plate",
+            "gtceu:dense_cosmic_neutronium_plate")
+        .inputFluids(
+            "gtceu:concrete 1000000")
+        .itemOutputs(
+            "kubejs:reinforced_base_casing")
+        .duration(20*45)
+        .EUt(GTValues.VA[GTValues.UXV])
+
+    sog.recipes.gtceu.assembler("supercritical_cryo_cooled_casing")
+        .itemInputs(
+            "gtceu:double_blue_steel_plate",
+            "gtceu:pure_cosmic_matter_plate",
+            "gtceu:double_blue_steel_plate",
+            "gtceu:pure_cosmic_matter_plate",
+            "kubejs:cryogenic_casing",
+            "gtceu:pure_cosmic_matter_plate",
+            "gtceu:double_blue_steel_plate",
+            "gtceu:pure_cosmic_matter_plate",
+            "gtceu:double_blue_steel_plate")
+        .inputFluids(
+            "gtceu:cryogenic_neutron_flow 10000")
+        .itemOutputs(
+            "kubejs:supercritical_cryo_cooled_casing")
+        .duration(20*45)
+        .EUt(GTValues.VA[GTValues.UXV])
+
+    sog.recipes.gtceu.assembly_line("mega_oreproc_facility")
+        .itemInputs(
+            "gtceu:uxv_macerator",
+            "gtceu:uxv_electrolyzer",
+            "gtceu:uxv_centrifuge",
+            "gtceu:uxv_sifter",
+            "16x kubejs:reinforced_base_casing",
+            "64x kubejs:adv_high_power_crushing_wheels",
+            "64x kubejs:adv_high_power_crushing_wheels",
+            "16x kubejs:reinforced_base_casing",
+            "16x kubejs:reinforced_base_casing",
+            "64x gtceu:adv_processing_plant",
+            "64x gtceu:adv_processing_plant",
+            "16x kubejs:reinforced_base_casing",
+            "16x kubejs:reinforced_base_casing",
+            "gtceu:uxv_conveyor_module",
+            "gtceu:uxv_conveyor_module",
+            "16x kubejs:reinforced_base_casing")
+        .inputFluids(
+            "gtceu:meta_stable_molten_kevlar 2500",
+            "gtceu:cosmic_matter 5000",
+            "gtceu:eternity 10000",
+            "gtceu:hypoxylon 20000")
+        .itemOutputs(
+            "gtceu:mega_oreproc_facility")
         .duration(20*1200)
         .EUt(GTValues.VA[GTValues.UXV])
 
-    sog.recipes.gtceu.assembly_line('hyper_separator')
+    sog.recipes.gtceu.assembly_line("distillation_facility_complex")
         .itemInputs(
-            'gtceu:uxv_centrifuge',
-            'gtceu:uxv_electromagnetic_separator',
-            'gtceu:uxv_electromagnetic_separator',
-            'gtceu:uxv_electrolyzer',
-            '16x kubejs:reinforced_base_casing',
-            '64x gtceu:chemical_plant',
-            '64x gtceu:chemical_plant',
-            '16x kubejs:reinforced_base_casing',
-            '16x kubejs:reinforced_base_casing',
-            '4x kubejs:advanced_air_intake_hatch',
-            '4x kubejs:advanced_air_intake_hatch',
-            '16x kubejs:reinforced_base_casing',
-            '16x kubejs:reinforced_base_casing',
-            'gtceu:uxv_electric_pump',
-            'gtceu:uxv_electric_pump',
-            '16x kubejs:reinforced_base_casing'
-        )
+            "gtceu:uxv_distillery",
+            "64x gtceu:extreme_cracking_unit",
+            "64x gtceu:extreme_cracking_unit",
+            "gtceu:uxv_distillery",
+            "16x kubejs:reinforced_base_casing",
+            "64x gtceu:chemical_plant",
+            "64x gtceu:chemical_plant",
+            "16x kubejs:reinforced_base_casing",
+            "16x kubejs:reinforced_base_casing",
+            "4x kubejs:advanced_air_intake_hatch",
+            "4x kubejs:advanced_air_intake_hatch",
+            "16x kubejs:reinforced_base_casing",
+            "16x kubejs:reinforced_base_casing",
+            "gtceu:uxv_electric_pump",
+            "gtceu:uxv_electric_pump",
+            "16x kubejs:reinforced_base_casing")
         .inputFluids(
-            'gtceu:meta_stable_molten_kevlar 2500',
-            'gtceu:cosmic_matter 5000',
-            'gtceu:eternity 10000',
-            'gtceu:hypoxylon 20000'
-        )
-        .itemOutputs('gtceu:hyper_separator')
+            "gtceu:meta_stable_molten_kevlar 2500",
+            "gtceu:cosmic_matter 5000",
+            "gtceu:eternity 10000",
+            "gtceu:hypoxylon 20000")
+        .itemOutputs(
+            "gtceu:distillation_facility_complex")
         .duration(20*1200)
         .EUt(GTValues.VA[GTValues.UXV])
-    
-        sog.recipes.gtceu.assembly_line('hyper_bio_lab')    
+
+
+    sog.recipes.gtceu.assembly_line("hyper_separator")
         .itemInputs(
-            '64x gtceu:bio_lab',
-            '64x gtceu:large_bacterial_bat',
-            '64x gtceu:uhv_hermetic_casing',
-            '6x gtceu:uxv_electric_pump',
-            '64x gtceu:sterilizing_filter_casing',
-            '64x gtceu:dense_hypoxylon_plate',
-            '4x kubejs:cosmic_processor_mainframe'
-        )
+            "gtceu:uxv_centrifuge",
+            "gtceu:uxv_electromagnetic_separator",
+            "gtceu:uxv_electromagnetic_separator",
+            "gtceu:uxv_electrolyzer",
+            "16x kubejs:reinforced_base_casing",
+            "64x gtceu:chemical_plant",
+            "64x gtceu:chemical_plant",
+            "16x kubejs:reinforced_base_casing",
+            "16x kubejs:reinforced_base_casing",
+            "4x kubejs:advanced_air_intake_hatch",
+            "4x kubejs:advanced_air_intake_hatch",
+            "16x kubejs:reinforced_base_casing",
+            "16x kubejs:reinforced_base_casing",
+            "gtceu:uxv_electric_pump",
+            "gtceu:uxv_electric_pump",
+            "16x kubejs:reinforced_base_casing")
         .inputFluids(
-            'gtceu:eternity 5000',
-            'gtceu:antimatter 10000',
-            'gtceu:sterilized_growth_medium 15000',
-            'gtceu:stropharic_hypoxylon 10000'
-        )
-        .itemOutputs('gtceu:hyper_bio_lab')
+            "gtceu:meta_stable_molten_kevlar 2500",
+            "gtceu:cosmic_matter 5000",
+            "gtceu:eternity 10000",
+            "gtceu:hypoxylon 20000")
+        .itemOutputs(
+            "gtceu:hyper_separator")
+        .duration(20*1200)
+        .EUt(GTValues.VA[GTValues.UXV])
+
+    sog.recipes.gtceu.assembly_line("hyper_bio_lab")    
+        .itemInputs(
+            "64x gtceu:bio_lab",
+            "64x gtceu:large_bacterial_bat",
+            "64x gtceu:uhv_hermetic_casing",
+            "6x gtceu:uxv_electric_pump",
+            "64x gtceu:sterilizing_filter_casing",
+            "64x gtceu:dense_hypoxylon_plate",
+            "4x kubejs:cosmic_processor_mainframe")
+        .inputFluids(
+            "gtceu:eternity 5000",
+            "gtceu:antimatter 10000",
+            "gtceu:sterilized_growth_medium 15000",
+            "gtceu:stropharic_hypoxylon 10000")
+        .itemOutputs(
+            "gtceu:hyper_bio_lab")
         .EUt(GTValues.VA[GTValues.UXV])
         .duration(500)
 
-    sog.recipes.gtceu.assembler('blazing_filter_casing')
+    sog.recipes.gtceu.assembler("blazing_filter_casing")
         .itemInputs(
-            'gtceu:uiv_electric_motor',
-            'gtceu:uiv_emitter',
-            '4x gtceu:sterilizing_filter_casing',
-        	'64x minecraft:blaze_rod'
-        )
-        .inputFluids('gtceu:antimatter 200')
-        .itemOutputs('phoenix_gregic_additons:blazing_filter_casing')
+            "gtceu:uiv_electric_motor",
+            "gtceu:uiv_emitter",
+            "4x gtceu:sterilizing_filter_casing",
+        	"64x minecraft:blaze_rod")
+        .inputFluids(
+            "gtceu:antimatter 200")
+        .itemOutputs(
+            "phoenix_gregic_additons:blazing_filter_casing")
         .cleanroom(CleanroomType.STERILE_CLEANROOM)
         .duration(200)
         .EUt(GTValues.VA[GTValues.UIV])
 
-    sog.recipes.gtceu.assembly_line('hyper_crystallization_chamber')
+    sog.recipes.gtceu.assembly_line("hyper_crystallization_chamber")
         .itemInputs(
-            '16x gtceu:uiv_autoclave',
-            '64x gtceu:large_autoclave',
-            '64x gtceu:gravi_star',
-            '16x avaritia:eternal_singularity',
-            '64x kubejs:energized_quantum_anomaly',
-            '2x gtceu:uxv_electric_pump',
-            '16x kubejs:space_time_heavy_plating'
-        )
+            "16x gtceu:uiv_autoclave",
+            "64x gtceu:large_autoclave",
+            "64x gtceu:gravi_star",
+            "16x avaritia:eternal_singularity",
+            "64x kubejs:energized_quantum_anomaly",
+            "2x gtceu:uxv_electric_pump",
+            "16x kubejs:space_time_heavy_plating")
         .inputFluids(
-            'gtceu:eternity 5000',
-            'gtceu:antimatter 10000',
-            'gtceu:radon 100000',
-            'gtceu:europium 100000'
-        )
-        .itemOutputs('gtceu:hyper_crystallization_chamber')
+            "gtceu:eternity 5000",
+            "gtceu:antimatter 10000",
+            "gtceu:radon 100000",
+            "gtceu:europium 100000")
+        .itemOutputs(
+            "gtceu:hyper_crystallization_chamber")
         .EUt(GTValues.VA[GTValues.UXV])
         .duration(500)
 
-    sog.shaped('gtceu:ulv_input_hatch', [
-            ' A ', 
-            'CBC',
-            ' C '  
-          ], {
-            A: '#forge:glass', 
-            B: 'gtceu:ulv_machine_hull',
-            C: 'gtceu:sticky_resin'
-          }
-        )
-
-    sog.recipes.gtceu.chemical_reactor('ethylbenzene_lcr')
-        .inputFluids(Fluid.of('gtceu:ethylene 1000'))
-        .inputFluids(Fluid.of('gtceu:benzene 1000'))
-        .outputFluids('gtceu:ethylbenzene 1000')
+    sog.recipes.gtceu.chemical_reactor("ethylbenzene_lcr")
+        .inputFluids(
+            Fluid.of("gtceu:ethylene 1000"))
+        .inputFluids(
+            Fluid.of("gtceu:benzene 1000"))
+        .outputFluids(
+            "gtceu:ethylbenzene 1000")
         .duration(20*20)
         .EUt((GTValues.VA[GTValues.HV]))
 
-    sog.shaped('gtceu:uev_machine_hull', [
-            'ABA', 
-            'CDC',
-            '   '  
-          ], {
-            A: 'gtceu:peek_plate', 
-            B: 'gtceu:resonant_essence_plate',
-            C: 'gtceu:draconium_single_cable',
-            D: 'gtceu:uev_machine_casing'
-          }
-        )
-    sog.recipes.gtceu.assembler('uev_machine_hull')
+    sog.recipes.gtceu.assembler("uev_machine_hull")
         .itemInputs(
-            'gtceu:uev_machine_casing',
-            '2x gtceu:draconium_single_cable'
-        )
-        .inputFluids('gtceu:peek 288')
-        .itemOutputs('gtceu:uev_machine_hull')
+            "gtceu:uev_machine_casing",
+            "2x gtceu:draconium_single_cable")
+        .inputFluids(
+            "gtceu:peek 288")
+        .itemOutputs(
+            "gtceu:uev_machine_hull")
         .duration(20*2.5)
         .EUt(GTValues.VA[GTValues.LV])
-    sog.shaped('gtceu:uiv_machine_hull', [
-            'ABA', 
-            'CDC',
-            '   '  
-          ], {
-            A: 'gtceu:hypoxylon_plate', 
-            B: 'gtceu:draconium_plate',
-            C: 'gtceu:awakened_draconium_single_cable',
-            D: 'gtceu:uiv_machine_casing'
-          }
-        )
-    sog.recipes.gtceu.assembler('uiv_machine_hull')
+
+    sog.recipes.gtceu.assembler("uiv_machine_hull")
         .itemInputs(
-            'gtceu:uiv_machine_casing',
-            '2x gtceu:awakened_draconium_single_cable'
-        )
-        .inputFluids('gtceu:hypoxylon 288')
-        .itemOutputs('gtceu:uiv_machine_hull')
+            "gtceu:uiv_machine_casing",
+            "2x gtceu:awakened_draconium_single_cable")
+        .inputFluids(
+            "gtceu:hypoxylon 288")
+        .itemOutputs(
+            "gtceu:uiv_machine_hull")
         .duration(20*2.5)
         .EUt(GTValues.VA[GTValues.LV])
-    sog.shaped('gtceu:uxv_machine_hull', [
-            'ABA', 
-            'CDC',
-            '   '  
-          ], {
-            A: 'gtceu:kevlar_plate', 
-            B: 'gtceu:chaos_plate',
-            C: 'gtceu:chaos_single_wire',
-            D: 'gtceu:uxv_machine_casing'
-          }
-        )
-    sog.recipes.gtceu.assembler('uxv_machine_hull')
+
+    sog.recipes.gtceu.assembler("uxv_machine_hull")
         .itemInputs(
-            'gtceu:uxv_machine_casing',
-            '2x gtceu:chaos_single_wire'
-        )
-        .inputFluids('gtceu:meta_stable_molten_kevlar 288')
-        .itemOutputs('gtceu:uxv_machine_hull')
+            "gtceu:uxv_machine_casing",
+            "2x gtceu:chaos_single_wire")
+        .inputFluids(
+            "gtceu:meta_stable_molten_kevlar 288")
+        .itemOutputs(
+            "gtceu:uxv_machine_hull")
         .duration(20*2.5)
         .EUt(GTValues.VA[GTValues.LV])
-    sog.recipes.gtceu.assembler('opv_machine_hull')
+
+    sog.recipes.gtceu.assembler("opv_machine_hull")
         .itemInputs(
-            'gtceu:opv_machine_casing',
-            '2x gtceu:chaos_single_wire'
-        )
-        .inputFluids('gtceu:meta_stable_molten_zylon 288')
-        .itemOutputs('gtceu:opv_machine_hull')
+            "gtceu:opv_machine_casing",
+            "2x gtceu:chaos_single_wire")
+        .inputFluids(
+            "gtceu:meta_stable_molten_zylon 288")
+        .itemOutputs(
+            "gtceu:opv_machine_hull")
         .duration(20*2.5)
-        .EUt(GTValues.VA[GTValues.LV])
-    sog.shapeless('gtmthings:wireless_energy_terminal', [
-            'gtmthings:advanced_terminal',
-            'gtceu:energy_crystal'
-          ])
-          
-    sog.recipes.gtceu.assembler('quantum_field_stabilization_casing')
+        .EUt(GTValues.VA[GTValues.LV])          
+
+    sog.recipes.gtceu.assembler("quantum_field_stabilization_casing")
         .itemInputs(
-            'gtceu:double_solar_radiation_alloy_plate',
-            'gtceu:pure_cosmic_matter_plate',
-            'gtceu:double_solar_radiation_alloy_plate',
-            'gtceu:pure_cosmic_matter_plate',
-            'soggtaddon:ultra_dense_collider_casing',
-            'gtceu:pure_cosmic_matter_plate',
-            'gtceu:double_solar_radiation_alloy_plate',
-            'gtceu:pure_cosmic_matter_plate',
-            'gtceu:double_solar_radiation_alloy_plate'
-        )
-        .itemOutputs('soggtaddon:quantum_field_stabilization_casing')
-        .duration(20*2)
-        .EUt(GTValues.VA[GTValues.UXV])
-    sog.recipes.gtceu.assembler('ultra_dense_collider_casing')
-        .itemInputs(
-            'gtceu:double_solar_radiation_alloy_plate',
-            'gtceu:pure_cosmic_matter_plate',
-            'gtceu:double_solar_radiation_alloy_plate',
-            'gtceu:pure_cosmic_matter_plate',
-            'kubejs:highly_reinforced_radioactive_casing',
-            'gtceu:pure_cosmic_matter_plate',
-            'gtceu:double_solar_radiation_alloy_plate',
-            'gtceu:pure_cosmic_matter_plate',
-            'gtceu:double_solar_radiation_alloy_plate'
-        )
-        .itemOutputs('soggtaddon:ultra_dense_collider_casing')
-        .duration(20*2)
-        .EUt(GTValues.VA[GTValues.UXV])
-        sog.recipes.gtceu.assembler('high_energy_collider_casing')
-        .itemInputs(
-            'gtceu:double_solar_radiation_alloy_plate',
-            'gtceu:double_solar_radiation_alloy_plate',
-            'gtceu:double_solar_radiation_alloy_plate',
-            'gtceu:double_solar_radiation_alloy_plate',
-            'soggtaddon:quantum_field_stabilization_casing',
-            'gtceu:double_solar_radiation_alloy_plate',
-            'gtceu:double_solar_radiation_alloy_plate',
-            'gtceu:double_solar_radiation_alloy_plate',
-            'gtceu:double_solar_radiation_alloy_plate'
-        )
-        .itemOutputs('soggtaddon:high_energy_collider_casing')
+            "gtceu:double_solar_radiation_alloy_plate",
+            "gtceu:pure_cosmic_matter_plate",
+            "gtceu:double_solar_radiation_alloy_plate",
+            "gtceu:pure_cosmic_matter_plate",
+            "soggtaddon:ultra_dense_collider_casing",
+            "gtceu:pure_cosmic_matter_plate",
+            "gtceu:double_solar_radiation_alloy_plate",
+            "gtceu:pure_cosmic_matter_plate",
+            "gtceu:double_solar_radiation_alloy_plate")
+        .itemOutputs(
+            "soggtaddon:quantum_field_stabilization_casing")
         .duration(20*2)
         .EUt(GTValues.VA[GTValues.UXV])
 
-    sog.recipes.gtceu.mixer('diluting_sulfuric_acid')
-        .inputFluids(Fluid.of('gtceu:sulfuric_acid 1000'))
-        .inputFluids(Fluid.of('minecraft:water 1000'))
-        .outputFluids('gtceu:diluted_sulfuric_acid 1000')
+    sog.recipes.gtceu.assembler("ultra_dense_collider_casing")
+        .itemInputs(
+            "gtceu:double_solar_radiation_alloy_plate",
+            "gtceu:pure_cosmic_matter_plate",
+            "gtceu:double_solar_radiation_alloy_plate",
+            "gtceu:pure_cosmic_matter_plate",
+            "kubejs:highly_reinforced_radioactive_casing",
+            "gtceu:pure_cosmic_matter_plate",
+            "gtceu:double_solar_radiation_alloy_plate",
+            "gtceu:pure_cosmic_matter_plate",
+            "gtceu:double_solar_radiation_alloy_plate")
+        .itemOutputs(
+            "soggtaddon:ultra_dense_collider_casing")
+        .duration(20*2)
+        .EUt(GTValues.VA[GTValues.UXV])
+
+    sog.recipes.gtceu.assembler("high_energy_collider_casing")
+        .itemInputs(
+            "gtceu:double_solar_radiation_alloy_plate",
+            "gtceu:double_solar_radiation_alloy_plate",
+            "gtceu:double_solar_radiation_alloy_plate",
+            "gtceu:double_solar_radiation_alloy_plate",
+            "soggtaddon:quantum_field_stabilization_casing",
+            "gtceu:double_solar_radiation_alloy_plate",
+            "gtceu:double_solar_radiation_alloy_plate",
+            "gtceu:double_solar_radiation_alloy_plate",
+            "gtceu:double_solar_radiation_alloy_plate")
+        .itemOutputs(
+            "soggtaddon:high_energy_collider_casing")
+        .duration(20*2)
+        .EUt(GTValues.VA[GTValues.UXV])
+
+    sog.recipes.gtceu.mixer("diluting_sulfuric_acid")
+        .inputFluids(
+            Fluid.of("gtceu:sulfuric_acid 1000"))
+        .inputFluids(
+            Fluid.of("minecraft:water 1000"))
+        .outputFluids(
+            "gtceu:diluted_sulfuric_acid 1000")
         .duration(20*2.5)
         .EUt((GTValues.VA[GTValues.HV]))
 })

--- a/.minecraft/kubejs/server_scripts/mainlines/gregification_craftingrecipes.js
+++ b/.minecraft/kubejs/server_scripts/mainlines/gregification_craftingrecipes.js
@@ -1,0 +1,1028 @@
+ServerEvents.recipes(sog => {
+    // Shaped Crafting Recipes
+
+    sog.remove({ id: "enderio:stick" })
+    sog.shaped("4x minecraft:stick", [
+        " A ", 
+        " A ",
+        "   "],
+        {
+            A: "#minecraft:logs"
+        })
+    sog.shaped("gtceu:firebricks", [
+        "ABA", 
+        "BCB",
+        "ABA"],
+        {
+            A: "gtceu:firebrick", 
+            B: "gtceu:gypsum_dust",
+            C: "gtceu:concrete_bucket"
+        })
+    sog.shaped("gtceu:lp_steam_alloy_smelter", [
+        "ABA", 
+        "CDC",
+        "AAA"],
+        {
+            A: "gtceu:bronze_small_fluid_pipe", 
+            B: "minecraft:diamond",
+            C: "minecraft:furnace",
+            D: "gtceu:bronze_brick_casing"
+        })
+    sog.shaped("watersources:water_source_tier_1", [
+        "ABA",
+        "C C",
+        "ABA"],
+        {
+            A: "gtceu:firebrick", 
+            B: "minecraft:glass",
+            C: "minecraft:water_bucket"
+        })
+    sog.shaped("ironfurnaces:iron_furnace", [
+        "AAA", 
+        "CBD",
+        "AAA"],
+        {
+            A: "gtceu:iron_plate",
+            B: "ironfurnaces:copper_furnace",
+            C: "#forge:tools/hammers",
+            D: "#forge:tools/wrenches"
+        })
+    sog.shaped("ironfurnaces:gold_furnace", [
+        "ABA",
+        "BCB",
+        "ABA"],
+        {
+            A: "minecraft:glass",
+            B: "minecraft:gold_block",
+            C: "ironfurnaces:iron_furnace"
+        })
+    sog.shaped("gtceu:lv_mixer", [
+        "ABA", 
+        "ACA",
+        "DED"],
+        {
+            A: "enderio:soularium_ingot",
+            B: "gtceu:tin_rotor",
+            C: "gtceu:lv_electric_motor",
+            D: "#gtceu:circuits/lv",
+            E: "gtceu:lv_machine_hull"
+        })
+    sog.shaped("gtceu:mv_mixer", [
+        "ABA",
+        "ACA",
+        "DED"],
+        {
+            A: "enderio:soularium_ingot",
+            B: "gtceu:cobalt_brass_gear",
+            C: "gtceu:mv_electric_motor",
+            D: "#gtceu:circuits/mv",
+            E: "gtceu:mv_machine_hull"
+        })
+    sog.shaped("ae2:controller", [
+        "ABA", 
+        "BCB",
+        "ADA"],
+        {
+            A: "gtceu:platinum_ingot",
+            B: "gtceu:lpic_chip",
+            C: "gtceu:hv_machine_hull",
+            D: "#gtceu:circuits/hv"
+        })
+    sog.shaped("bonsaitrees3:bonsaipot", [
+        "AAA", 
+        "ABA",
+        "AAA"],
+        {
+            A: "gtceu:firebrick",
+            B: "minecraft:dirt"
+        })
+
+    sog.shaped("ae2:cell_component_1k", [
+        "ABA", 
+        "BCB",
+        "ABA"],
+        {
+            A: "minecraft:redstone",
+            B: "gtceu:certus_quartz_gem",
+            C: "#gtceu:circuits/lv"
+        })
+    sog.shaped("ae2:cell_component_4k", [
+        "ABA", 
+        "BCB",
+        "ABA"],
+        {
+            A: "minecraft:redstone",
+            B: "gtceu:certus_quartz_gem",
+            C: "#gtceu:circuits/mv"
+        })
+    sog.shaped("ae2:cell_component_16k", [
+        "ABA", 
+        "BCB",
+        "ABA"],
+        {
+            A: "minecraft:redstone",
+            B: "gtceu:certus_quartz_gem",
+            C: "#gtceu:circuits/hv"
+        })
+    sog.shaped("ae2:cell_component_64k", [
+        "ABA", 
+        "BCB",
+        "ABA"],
+        {
+            A: "minecraft:redstone",
+            B: "gtceu:certus_quartz_gem",
+            C: "#gtceu:circuits/ev"
+        })
+    sog.shaped("ae2:cell_component_256k", [
+        "ABA", 
+        "BCB",
+        "ABA"],
+        {
+            A: "minecraft:redstone",
+            B: "gtceu:certus_quartz_gem",
+            C: "#gtceu:circuits/iv"
+        })
+    sog.shaped("megacells:cell_component_1m", [
+        "ABA",
+        "CDC",
+        "ACA"],
+        {
+            A: "ae2:sky_dust",
+            B: "megacells:accumulation_processor",
+            C: "ae2:cell_component_256k",
+            D: "#gtceu:circuits/luv"
+        })
+    sog.shaped("megacells:cell_component_4m",[
+        "ABA",
+        "CDC",
+        "ACA"],
+        {
+            A: "#forge:dusts/ender_pearl",
+            B: "megacells:accumulation_processor",
+            C: "megacells:cell_component_1m",
+            D: "#gtceu:circuits/zpm"
+        })
+    sog.shaped("megacells:cell_component_16m",[
+        "ABA",
+        "CDC",
+        "ACA"],
+        {
+            A: "#forge:dusts/ender_pearl",
+            B: "megacells:accumulation_processor",
+            C: "megacells:cell_component_4m",
+            D: "#gtceu:circuits/uv"
+        })
+    sog.shaped("megacells:cell_component_64m",[
+        "ABA",
+        "CDC",
+        "ACA"],
+        {
+            A: "ae2:matter_ball",
+            B: "megacells:accumulation_processor",
+            C: "megacells:cell_component_16m",
+            D: "#gtceu:circuits/uhv"
+        })
+    sog.shaped("megacells:cell_component_256m",[
+        "ABA",
+        "CDC",
+        "ACA"],
+        {
+            A: "ae2:matter_ball",
+            B: "megacells:accumulation_processor",
+            C: "megacells:cell_component_64m",
+            D: "#gtceu:circuits/uev"
+        })
+    sog.shaped("ae2:drive", [
+        "ABA", 
+        "C C",
+        "ABA"],
+        {
+            A: "gtceu:platinum_ingot",
+            B: "#gtceu:circuits/hv",
+            C: "enderio:me_conduit"
+        })
+    sog.shaped("ad_astra:nasa_workbench", [
+        "ABA", 
+        "CDC",
+        "EFE"],
+        {
+            A: "gtceu:steel_frame",
+            B: "gtceu:platinum_single_wire",
+            C: "gtceu:double_steel_plate",
+            D: "gtceu:kanthal_coil_block",
+            E: "#gtceu:circuits/ev",
+            F: "gtceu:steel_block"
+        })
+    sog.shaped("bigger_ae2:advanced_fluid_cell_housing", [
+        "ABA",
+        "B B",
+        "CCC"],
+        {
+            A: "#gtceu:circuits/luv",
+            B: "gtceu:certus_quartz_plate",
+            C: "gtceu:rhodium_plated_palladium_plate"
+        })
+    sog.shaped("bigger_ae2:quantum_cell_component", [
+        "ADA",
+        "BCB",
+        "ABA"],
+        {
+            A: "gtceu:resonant_naquadah_plate",
+            B: "ae2:cell_component_256k",
+            C: "gtceu:duranium_plate",
+            D: "#gtceu:circuits/zpm"
+        })
+    sog.shaped("bigger_ae2:digital_singularity_cell_component", [
+        "ADA",
+        "BCB",
+        "ABA"],
+        {
+            A: "gtceu:cleaned_californium_plate",
+            B: "bigger_ae2:quantum_cell_component",
+            C: "gtceu:neutronium_plate",
+            D: "#gtceu:circuits/uv"
+        })
+    sog.shaped("expandedae:artificial_universe_fluid_cell", [
+        "ADA",
+        "BCB",
+        "ABA"],
+        {
+            A: "gtceu:resonant_essence_plate",
+            B: "bigger_ae2:digital_singularity_cell_component",
+            C: "avaritia:eternal_singularity",
+            D: "#gtceu:circuits/uev"
+        })
+    sog.shaped("expandedae:artificial_universe_item_cell", [
+        "ADA",
+        "BCB",
+        "ABA"],
+        {
+            A: "gtceu:cosmic_neutronium_plate",
+            B: "bigger_ae2:digital_singularity_cell_component",
+            C: "avaritia:eternal_singularity",
+            D: "#gtceu:circuits/uev"
+        })
+    sog.shaped("gtceu:moonminer", [
+        "ABA",
+        "CDC",
+        "BCB"],
+        {
+            A: "#gtceu:circuits/ev",
+            B: "ad_astra:desh_block",
+            C: "#gtceu:circuits/ev",
+            D: "ad_astra:moon_globe"
+        }).id("gtceu:shaped/moonminer")
+    sog.shaped("ae2:crafting_unit", [
+        "ABA",
+        "CDC",
+        "ABA"],
+        {
+            A: "gtceu:titanium_ingot",
+            B: "gtceu:cpu_chip",
+            C: "enderio:dense_me_conduit",
+            D: "#gtceu:circuits/hv"
+        }).id("ae2:unit")
+    sog.shaped("ae2:pattern_provider", [
+        "ABA",
+        "C C",
+        "ABA"],
+        {
+            A: "gtceu:titanium_ingot",
+            B: "gtceu:cpu_chip",
+            C: "enderio:dense_me_conduit"
+        }).id("ae2:patternprov")
+    sog.shaped("ae2:molecular_assembler", [
+        "ABA",
+        "C C",
+        "ABA"],
+        {
+            A: "gtceu:titanium_ingot",
+            B: "gtceu:cpu_chip",
+            C: "solarflux:photovoltaic_cell_1"
+        }).id("ae2:molecularasse")
+    sog.shaped("gtceu:starextractor", [
+        "ABA",
+        "CDC",
+        "BCB"],
+        {
+            A: "#gtceu:circuits/iv",
+            B: "gtceu:polybenzimidazole_plate",
+            C: "#gtceu:circuits/iv",
+            D: "gtceu:iridium_frame"
+        }).id("gtceu:shaped/starextractor")
+    sog.shaped("bloodmagic:altar", [
+        "A A",
+        "ABA",
+        "CCC"],
+        {
+            A: "gtceu:indium_gallium_phosphide_ingot",
+            B: "#gtceu:circuits/luv",
+            C: "gtceu:dense_rhodium_plated_palladium_plate"
+        }
+        ).id("bm:altar")
+    sog.shaped("angelring:angel_ring", [
+        "A A",
+        "ABA",
+        "CCC"],
+        {
+            A: "gtceu:manganese_phosphide_ingot",
+            B: "gtceu:lv_field_generator",
+            C: "gtceu:double_platinum_plate"
+        }).id("ag:angel_ring")
+    sog.shaped("gtceu:altart2", [
+        "ABA",
+        "CDC",
+        "CEC"],
+        {
+            A: "gtceu:dense_rhodium_plated_palladium_plate",
+            B: "gtceu:hsss_frame",
+            C: "#gtceu:circuits/luv",
+            D: "bloodmagic:altar",
+            E: "megacells:bulk_cell_component"
+        }).id("sog:altart2")
+    sog.shaped("gtceu:mega_blast_furnace", [
+        "ABA",
+        "CDC",
+        "EBE"],
+        {
+            A: "gtceu:dense_triplatirium_235_plate",
+            B: "gtceu:atomic_casing",
+            C: "gtceu:zpm_field_generator",
+            D: "gtceu:electric_blast_furnace",
+            E: "gtceu:naquadah_alloy_buzz_saw_blade"
+        })
+    sog.shaped("gtceu:mega_vacuum_freezer", [
+        "ABA",
+        "CDC",
+        "EBE"],
+        {
+            A: "gtceu:dense_triplatirium_235_plate",
+            B: "gtceu:atomic_casing",
+            C: "gtceu:zpm_field_generator",
+            D: "gtceu:vacuum_freezer",
+            E: "gtceu:naquadah_alloy_buzz_saw_blade"
+        })
+    sog.shaped("gtceu:atomicforge", [
+        "ABA",
+        "CDC",
+        "CEC"],
+        {
+            A: "gtceu:dense_atomic_alloy_plate",
+            B: "gtceu:mega_blast_furnace",
+            C: "gtceu:atomic_alloy_foil",
+            D: "#gtceu:circuits/uv",
+            E: "gtceu:zpm_fusion_reactor"
+        }).id("sog:atomicforge")
+    sog.shaped("gtceu:reinforced_atomicforge", [
+        "ABA",
+        "CDC",
+        "CEC"],
+        {
+            A: "gtceu:dense_zylon_plate",
+            B: "gtceu:atomicforge",
+            C: "gtceu:infinity_screw",
+            D: "#gtceu:circuits/uxv",
+            E: "gtceu:uev_fusion_reactor"
+        }).id("sog:reinforced_atomicforge")
+    sog.shaped("gtceu:starcondenser", [
+        "ABA",
+        "BDB",
+        "CCC"],
+        {
+            A: "#gtceu:circuits/uv",
+            B: "gtceu:atomic_alloy_frame",
+            C: "gtceu:atomic_casing",
+            D: "kubejs:condensed_star_matter"
+        }).id("sog:star_condenser")
+    sog.shaped("gtceu:blacklight", [
+        "ABA",
+        "DCD",
+        "ABA"],
+        {
+            A: "gtceu:tungsten_carbide_gear",
+            B: "gtceu:chemical_purple_dye",
+            C: "gtceu:purple_glass_lens",
+            D: "gtceu:triplatirium_235_foil"
+        }).id("gt:blacklight")
+    sog.shaped("avaritia:diamond_lattice", [
+        " BA",
+        "BBB",
+        "AB "],
+        {
+            A: "gtceu:quantum_star",
+            B: "gtceu:diamond_plate"
+        }).id("sog:lattice")
+    sog.shaped("draconicevolution:particle_generator", [
+        "ABA",
+        "BCB",
+        "ABA"],
+        {
+            A: "gtceu:neutronium_plate",
+            B: "kubejs:fallen_singularity",
+            C: "draconicevolution:draconium_core"
+        }).id("de:particlegen")
+    sog.shaped("draconicevolution:energy_core_stabilizer", [
+        "ABA",
+        "BCB",
+        "ABA"],
+        {
+            A: "gtceu:dense_crystal_matrix_plate",
+            B: "kubejs:quantum_energy_capsule",
+            C: "draconicevolution:particle_generator"
+        }).id("de:energycore")
+    sog.shaped("gtceu:dimensional_matter_extractor", [
+        "ADA",
+        "BCB",
+        "ABA"],
+        {
+            A: "gtceu:atomic_casing",
+            B: "draconicevolution:energy_core_stabilizer",
+            C: "gtceu:uhv_machine_hull",
+            D: "kubejs:gravitational_containment_cell"
+        }).id("sog:dimensionalextractor")
+    sog.shaped("kubejs:neutronate_enriched_atomic_casing", [
+        " B ",
+        "BAB",
+        " B "],
+        {
+            A: "gtceu:atomic_casing",
+            B: "gtceu:ruthenium_trinium_americium_neutronate_hex_wire",
+        }).id("sog:neutronate")
+    sog.shaped("2x minecraft:paper", [
+        "BBB",
+        "BAB",
+        "BBB"],
+        {
+            A: Item.of("minecraft:water_bucket"),
+            B: "gtceu:wood_dust",
+        }).replaceIngredient({item: Item.of("minecraft:water_bucket")}, "minecraft:bucket")
+    sog.shaped("gtceu:mv_electric_extractinator", [
+        "ABC",
+        "DEF",
+        "BGA"],
+        {
+            A: "gtceu:mv_robot_arm",
+            B: "gtceu:transistor",
+            C: "gtceu:vanadium_steel_gear",
+            D: "gtceu:mv_conveyor_module",
+            E: "gtceu:mv_machine_hull",
+            F: "gtceu:mv_sensor",
+            G: "extractinator:extractinator",
+        })
+    sog.shaped("gtceu:hv_electric_extractinator", [
+        "ABC",
+        "DEF",
+        "GHA"],
+        {
+            A: "gtceu:hv_robot_arm",
+            B: "ae2:engineering_processor",
+            C: "gtceu:double_platinum_plate",
+            D: "gtceu:hv_conveyor_module",
+            E: "gtceu:hv_machine_hull",
+            F: "gtceu:hv_sensor",
+            G: "gtceu:lv_field_generator",
+            H: "extractinator:extractinator",
+        })
+    sog.shaped("gtceu:ev_electric_extractinator", [
+        "ABC",
+        "DEF",
+        "GHA"],
+        {
+            A: "gtceu:ev_robot_arm",
+            B: "gtceu:ev_voltage_coil",
+            C: "gtceu:ultimet_gear",
+            D: "gtceu:ev_conveyor_module",
+            E: "gtceu:ev_machine_hull",
+            F: "#gtceu:circuits/ev",
+            G: "gtceu:mpic_chip",
+            H: "extractinator:extractinator",
+        })
+    sog.shaped("gtceu:iv_electric_extractinator", [
+        "ABC",
+        "DEF",
+        "GHA"],
+        {
+            A: "gtceu:iv_robot_arm",
+            B: "gtceu:iv_voltage_coil",
+            C: "gtceu:osmiridium_gear",
+            D: "gtceu:iv_conveyor_module",
+            E: "gtceu:iv_machine_hull",
+            F: "gtceu:iv_sensor",
+            G: "minecraft:nether_star",
+            H: "extractinator:extractinator",
+        })
+    sog.shaped("gtceu:luv_electric_extractinator", [
+        "ABC",
+        "DEF",
+        "GHA"],
+        {
+            A: "gtceu:luv_robot_arm",
+            B: "gtceu:luv_voltage_coil",
+            C: "gtceu:osmiridium_gear",
+            D: "gtceu:luv_conveyor_module",
+            E: "gtceu:luv_machine_hull",
+            F: "gtceu:luv_sensor",
+            G: "gtceu:quantum_star",
+            H: "extractinator:extractinator",
+        })
+    sog.shaped("gtceu:zpm_electric_extractinator", [
+        "ABC",
+        "DEF",
+        "GHA"],
+        {
+            A: "gtceu:zpm_robot_arm",
+            B: "gtceu:zpm_voltage_coil",
+            C: "gtceu:naquadah_alloy_gear",
+            D: "gtceu:zpm_conveyor_module",
+            E: "gtceu:zpm_machine_hull",
+            F: "gtceu:zpm_sensor",
+            G: "gtceu:quantum_star",
+            H: "extractinator:extractinator",
+        })
+    sog.shaped("gtceu:uv_electric_extractinator", [
+        "ABC",
+        "DEF",
+        "GHA"],
+        {
+            A: "gtceu:uv_robot_arm",
+            B: "gtceu:uv_voltage_coil",
+            C: "gtceu:small_darmstadtium_gear",
+            D: "gtceu:uv_conveyor_module",
+            E: "gtceu:uv_machine_hull",
+            F: "gtceu:uv_sensor",
+            G: "gtceu:quantum_star",
+            H: "extractinator:extractinator",
+        })
+    sog.shaped("gtceu:uhv_electric_extractinator", [
+        "ABC",
+        "DEF",
+        "GHA"],
+        {
+            A: "gtceu:uhv_robot_arm",
+            B: "kubejs:uhv_voltage_coil",
+            C: "gtceu:neutronium_gear",
+            D: "gtceu:uhv_conveyor_module",
+            E: "gtceu:uhv_machine_hull",
+            F: "gtceu:uhv_sensor",
+            G: "gtceu:gravi_star",
+            H: "extractinator:extractinator",
+        })
+    sog.shaped("gtceu:uev_electric_extractinator", [
+        "ABC",
+        "DEF",
+        "GHA"],
+        {
+            A: "gtceu:uev_robot_arm",
+            B: "kubejs:uev_voltage_coil",
+            C: "gtceu:resonant_essence_gear",
+            D: "gtceu:uev_conveyor_module",
+            E: "gtceu:uev_machine_hull",
+            F: "gtceu:uev_sensor",
+            G: "gtceu:gravi_star",
+            H: "extractinator:extractinator",
+        })
+    sog.shaped("gtceu:uiv_electric_extractinator", [
+        "ABC",
+        "DEF",
+        "GHA"],
+        {
+            A: "gtceu:uiv_robot_arm",
+            B: "kubejs:uiv_voltage_coil",
+            C: "gtceu:draconium_gear",
+            D: "gtceu:uiv_conveyor_module",
+            E: "gtceu:uiv_machine_hull",
+            F: "gtceu:uiv_sensor",
+            G: "gtceu:gravi_star",
+            H: "extractinator:extractinator",
+        })
+    sog.shaped("gtceu:uxv_electric_extractinator", [
+        "ABC",
+        "DEF",
+        "GHA"],
+        {
+            A: "gtceu:uxv_robot_arm",
+            B: "kubejs:uxv_voltage_coil",
+            C: "gtceu:awakened_draconium_gear",
+            D: "gtceu:uxv_conveyor_module",
+            E: "gtceu:uxv_machine_hull",
+            F: "gtceu:uxv_sensor",
+            G: "gtceu:gravi_star",
+            H: "extractinator:extractinator",
+        })
+    sog.shaped("gtceu:robust_extractinator", [
+        "ABC",
+        "DEF",
+        "GHA"],
+        {
+            A: "gtceu:iv_robot_arm",
+            B: "gtceu:iv_voltage_coil",
+            C: "gtceu:osmiridium_gear",
+            D: "gtceu:iv_conveyor_module",
+            E: "gtceu:iv_electric_extractinator",
+            F: "gtceu:iv_sensor",
+            G: "gtceu:quantum_star",
+            H: "#gtceu:circuits/luv",
+        })
+    sog.shaped("gtceu:atomicompressor", [
+        "ABA",
+        "CDC",
+        "AEA"],
+        {
+            A: "kubejs:exotic_matter",
+            B: "kubejs:stabilized_collapsed_singularity",
+            C: "kubejs:stable_matter",
+            D: "gtceu:implosion_compressor",
+            E: "draconicevolution:energy_core_stabilizer"
+        })
+    sog.shaped("kubejs:quantum_resonant_core", [
+        "ABA",
+        "BCB",
+        "ABA"],
+        {
+            A: "gtceu:uv_field_generator",
+            B: "kubejs:stabilized_collapsed_singularity",
+            C: "kubejs:atomically_compressed_black_hole"
+        })
+    sog.shaped("gtceu:supercriticalvibrationsifter", [
+        "ABA",
+        "EDC",
+        "EFG"],
+        {
+            A: "gtceu:uv_field_generator",
+            B: "kubejs:quantum_resonant_core",
+            C: "gtceu:uv_emitter",
+            D: "gtceu:uhv_machine_hull",
+            E: "gtceu:uv_robot_arm",
+            F: "kubejs:gravitational_containment_cell",
+            G: "gtceu:uhv_ultimate_battery"
+        })
+    sog.shaped("enderio:ender_crystal", [
+        " A ",
+        "ABA",
+        " A "],
+        {
+            A: "minecraft:ender_pearl",
+            B: "enderio:vibrant_crystal",
+        })
+    sog.shaped("minecraft:netherite_upgrade_smithing_template", [
+        "ABA",
+        "ACA",
+        "AAA"],
+        {
+            A: "minecraft:diamond",
+            B: "minecraft:netherite_scrap",
+            C: "minecraft:netherrack"
+        })
+    sog.shaped("ad_astra:rocket_fin", [
+        " A ",
+        "ABA",
+        "ABA"],
+        {
+            A: "gtceu:dense_stainless_steel_plate",
+            B: "gtceu:smd_inductor"
+        })
+    sog.shaped("ad_astra:rocket_nose_cone", [
+        " A ",
+        "BCB",
+        "BDB"],
+        {
+            A: "minecraft:lightning_rod",
+            B: "gtceu:dense_magnetic_steel_plate",
+            C: "gtceu:lv_field_generator",
+            D: "gtceu:steel_block"
+        })
+    sog.shaped("ad_astra:fan", [
+        " A ",
+        "ABA",
+        " A "],
+        {
+            A: "gtceu:long_iron_rod",
+            B: "gtceu:steel_rotor"
+        })
+    sog.shaped("ad_astra:engine_frame", [
+        "ABB",
+        "ACA",
+        "BBA"],
+        {
+            A: "gtceu:long_iron_rod",
+            B: "gtceu:dense_stainless_steel_plate",
+            C: "gtceu:lv_field_generator"
+        })
+    sog.shaped("ad_astra:oxygen_gear", [
+        "A A",
+        "BCB",
+        "DED"],
+        {
+            A: "ad_astra:oxygen_tank",
+            B: "gtceu:dense_stainless_steel_plate",
+            C: "gtceu:long_iron_rod",
+            D: "gtceu:blue_steel_buzz_saw_blade",
+            E: "gtceu:blue_steel_frame"
+        })
+    sog.shaped("ad_astra:gas_tank", [
+        "ABC",
+        "ADE",
+        "AFC"],
+        {
+            A: "gtceu:dense_stainless_steel_plate",
+            B: "gtceu:long_iron_rod",
+            C: "gtceu:smd_transistor",
+            D: "gtceu:mask_filter",
+            E: "gtceu:stainless_steel_drum",
+            F: "gtceu:hv_battery_hull"
+        })
+    sog.shaped("gtceu:atomic_moonminer", [
+        "ABA",
+        "CDC",
+        "ABA"],
+        {
+            A: "gtceu:atomic_casing",
+            B: "gtceu:tritanium_coil_block",
+            C: "gtceu:wetware_processor_mainframe",
+            D: "gtceu:moonminer"
+        })
+    sog.shaped("kubejs:drilling_projector_module", [
+        "ABA",
+        "BCB",
+        "ABA"],
+        {
+            A: "kubejs:gravitational_fluctuation_module",
+            B: "gtceu:uv_parallel_hatch",
+            C: "gtceu:neutronium_drill_head"
+        })
+    sog.shaped("kubejs:pumping_projector_module", [
+        "ABA",
+        "BCB",
+        "ABA"],
+        {
+            A: "kubejs:gravitational_fluctuation_module",
+            B: "gtceu:uv_parallel_hatch",
+            C: "gtceu:uhv_electric_pump"
+        })
+    sog.shaped("kubejs:fusion_projector_module", [
+        "ABD",
+        "BCB",
+        "DBA"],
+        {
+            A: "kubejs:gravitational_fluctuation_module",
+            B: "avaritia:eternal_singularity",
+            C: "gtceu:uv_fusion_reactor",
+            D: "gtceu:fine_cosmic_neutronium_wire"
+        })
+    sog.shaped("kubejs:cosmic_projector_module", [
+        "ABD",
+        "BCB",
+        "DBA"],
+        {
+            A: "kubejs:gravitational_fluctuation_module",
+            B: "avaritia:eternal_singularity",
+            C: "gtceu:uhv_quantum_tank",
+            D: "kubejs:gravitational_containment_cell"
+        })
+    sog.shaped("kubejs:end_miner_module", [
+        "ABA",
+        "BCB",
+        "ABA"],
+        {
+            A: "minecraft:dragon_egg",
+            B: "minecraft:dragon_breath",
+            C: "draconicevolution:dragon_heart",
+        })
+    sog.shaped("gtceu:bio_lab", [
+        "ABA",
+        "ACA",
+        "ADA"],
+        {
+            A: "gtceu:plascrete",
+            B: "gtceu:stem_cells",
+            C: "gtceu:uhv_hermetic_casing",
+            D: "#gtceu:circuits/uev"
+        })
+    sog.shaped("gtceu:large_bacterial_bat", [
+        "ABA",
+        "AZA",
+        "AFA"],
+        {
+            A: "gtceu:plascrete",
+            B: "gtceu:stem_cells",
+            Z: "gtceu:petri_dish",
+            F: "#gtceu:circuits/uv"
+        })
+    sog.shaped("kubejs:component_tile_casing", [
+        "AAA",
+        "ABA",
+        "AAA"],
+        {
+            A: "gtceu:cosmic_titanium_plate",
+            B: "gtceu:tritanium_frame"
+        })
+    sog.shaped("kubejs:large_precision_casing", [
+        "AAA",
+        "ABA",
+        "AAA"],
+        {
+            A: "gtceu:cosmic_tungsten_plate",
+            B: "gtceu:hypoxylon_frame"
+        })
+    sog.shaped("kubejs:reinforced_computation_casing", [
+        "AAA",
+        "ABA",
+        "AAA"],
+        {
+            A: "gtceu:cosmic_iridium_plate",
+            B: "gtceu:computer_casing"
+        })
+    sog.shaped("2x kubejs:highly_reinforced_radioactive_casing", [
+        "AAA",
+        "ABA",
+        "AAA"],
+        {
+            A: "gtceu:stabilized_iridium_plate",
+            B: "kubejs:californite_heavy_plating"
+        })
+    sog.shaped("2x kubejs:stellar_powered_casing", [
+        "AAA",
+        "CBC",
+        "AAA"],
+        {
+            A: "gtceu:dense_antimatter_plate",
+            B: "kubejs:highly_reinforced_radioactive_casing",
+            C: "kubejs:draconium_heavy_plating"
+        })
+    sog.shaped("gtceu:atmospheric_collector", [
+        "ABA",
+        "DCD",
+        "ABA"],
+        {
+            A: "gtceu:luv_electric_pump",
+            B: "gtceu:laminated_glass",
+            C: "gtceu:luv_machine_hull",
+            D: "#gtceu:circuits/luv"
+        })
+    sog.shaped("gtceu:particle_implosion_chamber", [
+        "ABA",
+        "DCD",
+        "ABA"],
+        {
+            A: "gtceu:uhv_robot_arm",
+            B: "gtceu:atomic_casing",
+            C: "gtceu:uhv_machine_hull",
+            D: "#gtceu:circuits/uhv"
+        })
+    sog.shaped("ae2:energy_acceptor", [
+        "ABA",
+        "BCB",
+        "ABA"],
+        {
+            A: "gtceu:platinum_ingot",
+            B: "gtceu:lpic_chip",
+            C: "gtceu:hv_machine_hull",
+        })
+    sog.shaped("ae2:interface", [
+        "ABA",
+        "BDC",
+        "ACA"],
+        {
+            A: "gtceu:stainless_steel_ingot",
+            B: "ae2:annihilation_core",
+            C: "ae2:formation_core",
+            D: "enderio:me_conduit"
+        })
+    sog.shaped("ae2:import_bus", [
+        "ABA",
+        "BCB",
+        "   "],
+        {
+            A: "gtceu:stainless_steel_ingot",
+            B: "ae2:formation_core",
+            C: "minecraft:sticky_piston",
+        })
+    sog.shaped("ae2:export_bus", [
+        "ABA",
+        "BCB",
+        "   "],
+        {
+            A: "gtceu:stainless_steel_ingot",
+            B: "ae2:annihilation_core",
+            C: "minecraft:sticky_piston",
+        })
+    sog.shaped("avaritia:extreme_crafting_table", [
+        "BB ",
+        "AA ",
+        "   "],
+        {
+        A: "avaritia:crystal_matrix_ingot",
+        B: "minecraft:flint",
+        })
+    sog.shaped("gtceu:ulv_input_hatch", [
+        " A ", 
+        "CBC",
+        " C "],
+        {
+            A: "#forge:glass", 
+            B: "gtceu:ulv_machine_hull",
+            C: "gtceu:sticky_resin"
+        })
+    sog.shaped("gtceu:uev_machine_hull", [
+        "ABA", 
+        "CDC",
+        "   "],
+        {
+            A: "gtceu:peek_plate", 
+            B: "gtceu:resonant_essence_plate",
+            C: "gtceu:draconium_single_cable",
+            D: "gtceu:uev_machine_casing"
+        })
+    sog.shaped("gtceu:uiv_machine_hull", [
+        "ABA", 
+        "CDC",
+        "   "],
+        {
+            A: "gtceu:hypoxylon_plate", 
+            B: "gtceu:draconium_plate",
+            C: "gtceu:awakened_draconium_single_cable",
+            D: "gtceu:uiv_machine_casing"
+        })
+    sog.shaped("gtceu:uxv_machine_hull", [
+        "ABA", 
+        "CDC",
+        "   "],
+        {
+            A: "gtceu:kevlar_plate", 
+            B: "gtceu:chaos_plate",
+            C: "gtceu:chaos_single_wire",
+            D: "gtceu:uxv_machine_casing"
+        })
+    sog.shaped("gtmutils:infinite_spray_can",[
+        "ABC", 
+        "DEF",
+        "GHI"],
+        {
+            A: "gtceu:white_dye_spray_can", 
+            B: "gtceu:orange_dye_spray_can", 
+            C: "gtceu:magenta_dye_spray_can", 
+            D: "gtceu:light_blue_dye_spray_can", 
+            E: "#gtceu:circuits/hv",
+            F: "gtceu:yellow_dye_spray_can", 
+            G: "gtceu:lime_dye_spray_can", 
+            H: "gtceu:pink_dye_spray_can", 
+            I: "gtceu:gray_dye_spray_can"
+        })
+
+
+    // Shapeless Crafting Recipes
+
+    sog.shapeless("2x gtceu:rubber_planks", [
+            "gtceu:rubber_log"
+        ])
+    sog.shapeless("minecraft:egg", [
+        "minecraft:grass",
+        "hostilenetworks:overworld_prediction"
+        ])
+    sog.shapeless(Item.of("gtmutils:neutronium_credit", 1), [
+        "8x gtmutils:naquadah_credit"
+        ])
+    sog.shapeless(Item.of("gtmutils:naquadah_credit", 1), [
+        "8x gtmutils:osmium_credit"
+        ])
+
+    sog.shapeless(Item.of("gtmutils:osmium_credit", 1), [
+        "8x gtmutils:platinum_credit"
+        ])
+    sog.shapeless(Item.of("gtmutils:platinum_credit", 1), [
+        "8x gtmutils:gold_credit"
+        ])
+    sog.shapeless(Item.of("gtmutils:gold_credit", 1), [
+        "8x gtmutils:silver_credit"
+        ])
+    sog.shapeless(Item.of("gtmutils:silver_credit", 1), [
+        "8x gtmutils:cupronickel_credit"
+        ])
+    sog.shapeless(Item.of("gtmutils:copper_credit", 8), [
+        "1x gtmutils:cupronickel_credit"
+        ])
+    sog.shapeless("minecraft:bamboo", [
+        "minecraft:oak_sapling",
+        "minecraft:wheat_seeds",
+        "hostilenetworks:overworld_prediction"
+        ])
+    sog.shapeless("minecraft:beetroot_seeds", [
+        "minecraft:wheat_seeds",
+        "2x hostilenetworks:overworld_prediction"
+        ])
+    sog.shapeless("minecraft:pumpkin_seeds", [
+        "minecraft:beetroot_seeds",
+        "minecraft:wheat_seeds",
+        "hostilenetworks:overworld_prediction"
+        ])
+    sog.shapeless("gtmthings:wireless_energy_terminal", [
+        "gtmthings:advanced_terminal",
+        "gtceu:energy_crystal"
+        ])
+    sog.shapeless("ae2:interface", [
+        "ae2:cable_interface"
+        ])
+    sog.shapeless("ae2:pattern_provider", [
+        "ae2:cable_pattern_provider"
+        ])
+})

--- a/.minecraft/kubejs/startup_scripts/materials.js
+++ b/.minecraft/kubejs/startup_scripts/materials.js
@@ -1,4 +1,3 @@
-
 const $OreProperty = Java.loadClass('com.gregtechceu.gtceu.api.data.chemical.material.properties.OreProperty');
 Java.loadClass('com.gregtechceu.gtceu.api.data.chemical.material.Material'); // This line is generally not needed
 
@@ -150,19 +149,37 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
     const $DustProperty = Java.loadClass('com.gregtechceu.gtceu.api.data.chemical.material.properties.DustProperty');
     const $BlastProperty = Java.loadClass('com.gregtechceu.gtceu.api.data.chemical.material.properties.BlastProperty');
 
-GTMaterials.Neutronium.addFlags(GTMaterialFlags.GENERATE_FINE_WIRE, GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.GENERATE_RING, GTMaterialFlags.GENERATE_ROUND, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_SMALL_GEAR, GTMaterialFlags.GENERATE_BOLT_SCREW, GTMaterialFlags.GENERATE_DENSE)
-GTMaterials.StainlessSteel.addFlags(GTMaterialFlags.GENERATE_DENSE)
-
-GTMaterials.PolyvinylButyral.addFlags(GTMaterialFlags.GENERATE_FOIL)
-
-GTMaterials.Californium.setProperty(PropertyKey.DUST, new $DustProperty());
-
-GTMaterials.Nihonium.setProperty(PropertyKey.DUST, new $DustProperty());
-GTMaterials.Nihonium.setProperty(PropertyKey.INGOT, new $IngotProperty());
-
-GTMaterials.Thallium.setProperty(PropertyKey.DUST, new $DustProperty());
-GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
-
+    GTMaterials.Neutronium.addFlags(
+        GTMaterialFlags.GENERATE_FINE_WIRE,
+        GTMaterialFlags.GENERATE_FOIL,
+        GTMaterialFlags.GENERATE_RING,
+        GTMaterialFlags.GENERATE_ROUND,
+        GTMaterialFlags.GENERATE_GEAR,
+        GTMaterialFlags.GENERATE_SMALL_GEAR,
+        GTMaterialFlags.GENERATE_BOLT_SCREW,
+        GTMaterialFlags.GENERATE_DENSE
+    );
+    GTMaterials.StainlessSteel.addFlags(
+        GTMaterialFlags.GENERATE_DENSE
+    );
+    GTMaterials.PolyvinylButyral.addFlags(
+        GTMaterialFlags.GENERATE_FOIL
+    );
+    GTMaterials.Californium.setProperty(
+        PropertyKey.DUST, new $DustProperty()
+    );
+    GTMaterials.Nihonium.setProperty(
+        PropertyKey.DUST, new $DustProperty()
+    );
+    GTMaterials.Nihonium.setProperty(
+        PropertyKey.INGOT, new $IngotProperty()
+    );
+    GTMaterials.Thallium.setProperty(
+        PropertyKey.DUST, new $DustProperty()
+    );
+    GTMaterials.Thallium.setProperty(
+        PropertyKey.INGOT, new $IngotProperty()
+    );
 
 
 
@@ -317,7 +334,7 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .color(0x2b3d2d)
         .element('resonant_naquadah')
         .blastTemp(9100) 
-        .cableProperties(GTValues.V[GTValues.UV], 128, 2, true)
+        .cableProperties(GTValues.V[GTValues.UV], 256, 0, true)
         .iconSet(GTMaterialIconSet.SHINY)
         .flags(
             GTMaterialFlags.GENERATE_PLATE,
@@ -328,8 +345,7 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
             GTMaterialFlags.GENERATE_FOIL,
             GTMaterialFlags.NO_SMELTING,
             GTMaterialFlags.NO_ORE_SMELTING
-
-        )
+        );
     event.create('crystal_matrix')
         .ingot().liquid()
         .element('crystal_matrix')
@@ -337,21 +353,39 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .iconSet('shiny')
         .cableProperties(GTValues.V[GTValues.UHV], 256, 0, true)
         .fluidPipeProperties(100000, 64000, true, true, true, true)
-        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_FINE_WIRE, GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_ROTOR, GTMaterialFlags.GENERATE_DENSE);
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.GENERATE_FOIL,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_FRAME,
+            GTMaterialFlags.GENERATE_ROTOR,
+            GTMaterialFlags.GENERATE_DENSE
+        );
     event.create('infinity')
         .ingot()
         .element(GTElements.get("infinity"))
         .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
         .color(0xffffff)
         .iconSet('infinity')
-        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD,  GTMaterialFlags.GENERATE_LONG_ROD, GTMaterialFlags.GENERATE_RING, GTMaterialFlags.GENERATE_ROUND, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_SMALL_GEAR, GTMaterialFlags.GENERATE_BOLT_SCREW, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_DENSE);
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_ROD, 
+            GTMaterialFlags.GENERATE_LONG_ROD,
+            GTMaterialFlags.GENERATE_RING,
+            GTMaterialFlags.GENERATE_ROUND,
+            GTMaterialFlags.GENERATE_GEAR,
+            GTMaterialFlags.GENERATE_SMALL_GEAR,
+            GTMaterialFlags.GENERATE_BOLT_SCREW,
+            GTMaterialFlags.GENERATE_FRAME,
+            GTMaterialFlags.GENERATE_DENSE
+        );
     event.create('infinity_catalyst')
         .dust()
         .element(GTElements.get("infinity"))
         .color(0xffffff)
         .iconSet('infinity_catalyst')
         .ore(1, 1,)
-
     event.create("triplatirium_235")
         .ingot().liquid()
         .components('1x uranium-235', '1x uranium', '3x platinum', '1x duranium')
@@ -360,8 +394,15 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .blastTemp(10800)
         .color(0x47ffaf)
         .iconSet('metallic')
-        .flags(GTMaterialFlags.DECOMPOSITION_BY_CENTRIFUGING, GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_DENSE, GTMaterialFlags.NO_SMELTING);
-
+        .flags(
+            GTMaterialFlags.DECOMPOSITION_BY_CENTRIFUGING,
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_FOIL,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_FRAME,
+            GTMaterialFlags.GENERATE_DENSE,
+            GTMaterialFlags.NO_SMELTING
+        );
     event.create("atomic_alloy")
         .ingot()
         .components('14x californium', '1x uranium-235', '1x uranium', '3x platinum', '1x duranium')
@@ -369,8 +410,17 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .blastTemp(10800)
         .color(0x513499)
         .iconSet('bright')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION, GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_DENSE, GTMaterialFlags.GENERATE_ROTOR, GTMaterialFlags.GENERATE_BOLT_SCREW, GTMaterialFlags.NO_SMELTING);
-
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION,
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_FOIL,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_FRAME,
+            GTMaterialFlags.GENERATE_DENSE,
+            GTMaterialFlags.GENERATE_ROTOR,
+            GTMaterialFlags.GENERATE_BOLT_SCREW,
+            GTMaterialFlags.NO_SMELTING
+        );
     event.create("triplatirium_sulfate")
         .liquid()
         .color(0xbff52a)
@@ -412,18 +462,27 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .color(0x8f34eb)
         .element('antimatter')
         .iconSet('metallic')
-        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_DENSE, GTMaterialFlags.GENERATE_ROTOR, GTMaterialFlags.GENERATE_BOLT_SCREW, GTMaterialFlags.NO_SMELTING);
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_FOIL,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_FRAME,
+            GTMaterialFlags.GENERATE_DENSE,
+            GTMaterialFlags.GENERATE_ROTOR,
+            GTMaterialFlags.GENERATE_BOLT_SCREW,
+            GTMaterialFlags.NO_SMELTING
+        );
     event.create('reactable_fissioned_matter')
         .plasma()
         .color(0x270a4d)
-        event.create('cosmic_neutronium')
+    event.create('cosmic_neutronium')
         .ingot()
         .color(0x161616)
         .ore(1, 1,)
         .element('cosmic_neutronium')
         .iconSet('radioactive')
         .blastTemp(13000, 'highest', 2097152, 2400)
-        .cableProperties(GTValues.V[GTValues.OpV], 999, 0, true)
+        .cableProperties(GTValues.V[GTValues.OpV], 256, 0, true)
         .flags(
             GTMaterialFlags.GENERATE_PLATE, 
             GTMaterialFlags.GENERATE_ROD, 
@@ -435,40 +494,72 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
             GTMaterialFlags.GENERATE_BOLT_SCREW,
             GTMaterialFlags.GENERATE_SMALL_GEAR,
             GTMaterialFlags.GENERATE_ROUND,
-            GTMaterialFlags.GENERATE_SPRING
-        )
+            GTMaterialFlags.GENERATE_SPRING,
+            GTMaterialFlags.GENERATE_SPRING_SMALL
+        );
     event.create('heavy_duty_alloy_t1')
         .ingot()
         .color(0x333e47)
         .blastTemp(10000)
         .cableProperties(GTValues.V[GTValues.EV], 32, 0, true)
         .iconSet('metallic')
-        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_FINE_WIRE, GTMaterialFlags.NO_SMELTING)
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_GEAR,
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.NO_SMELTING
+        );
     event.create('heavy_duty_alloy_t2')
         .ingot()
         .color(0xfbff00)
         .blastTemp(10000)
         .iconSet('metallic')
-        .cableProperties(GTValues.V[GTValues.LuV], 64, 0, true)
-        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_FINE_WIRE, GTMaterialFlags.NO_SMELTING)
+        .cableProperties(GTValues.V[GTValues.LuV], 256, 0, true)
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_GEAR,
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.NO_SMELTING
+        );
     event.create('heavy_duty_alloy_t3')
         .ingot()
         .color(0xb2a7d4)
         .blastTemp(10000)
         .cableProperties(GTValues.V[GTValues.UHV], 1024, 0, true)
         .iconSet('metallic')
-        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_FINE_WIRE, GTMaterialFlags.NO_SMELTING)
-        event.create('heavy_duty_alloy_t4')
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_GEAR,
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.NO_SMELTING
+        );
+    event.create('heavy_duty_alloy_t4')
         .ingot().liquid()
         .color(0x17e0ff)
         .cableProperties(GTValues.V[GTValues.UXV], 24, 0, true)
         .iconSet('metallic')
-        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_FINE_WIRE)
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_GEAR,
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.GENERATE_SPRING,
+            GTMaterialFlags.GENERATE_SPRING_SMALL,
+            GTMaterialFlags.GENERATE_ROTOR
+        );
     event.create('mixed_alloy')
         .ingot()
         .color(0xe8c492)
         .iconSet('metallic')
-        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_FINE_WIRE)
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_GEAR,
+            GTMaterialFlags.GENERATE_FINE_WIRE
+        );
     event.create('kaemite')
         .ingot().liquid()
         .color(0x00cfff)
@@ -476,7 +567,13 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .element('kaemite')
         .iconSet('metallic')
         .cableProperties(GTValues.V[GTValues.UEV], 32, 0, true)
-        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_FINE_WIRE, GTMaterialFlags.GENERATE_FRAME)
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_GEAR,
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.GENERATE_FRAME
+        );
     event.create('acidic_venus_residue')
         .liquid()
         .color(0x944e09)
@@ -491,7 +588,16 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .element('resonant_essence')
         .iconSet('bright')
         .cableProperties(GTValues.V[GTValues.UEV], 256, 0, true)
-        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_FINE_WIRE, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_DENSE, GTMaterialFlags.GENERATE_ROTOR, GTMaterialFlags.GENERATE_BOLT_SCREW)
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_GEAR,
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.GENERATE_FRAME,
+            GTMaterialFlags.GENERATE_DENSE,
+            GTMaterialFlags.GENERATE_ROTOR,
+            GTMaterialFlags.GENERATE_BOLT_SCREW
+        );
     event.create('energized_superconductor')
         .ingot()
         .color(0xffa600)
@@ -516,63 +622,79 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .ingot()
         .color(0x6200ff)
         .iconSet('bright')
-        .cableProperties(GTValues.V[GTValues.ZPM], 32, 0, true)
+        .cableProperties(GTValues.V[GTValues.ZPM], 256, 0, true)
     event.create('teslarium')
         .ingot()
         .color(0x4800bd)
         .iconSet('shiny')
         .element('teslarium')
-        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_FINE_WIRE)
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_GEAR,
+            GTMaterialFlags.GENERATE_FINE_WIRE
+        );
 
-        // B A C T E R I A L   S T U F F
 
-        event.create("raw_bacterial_dna")
+    // B A C T E R I A L   S T U F F
+
+    event.create("raw_bacterial_dna")
         .liquid()
         .color(0xf595eb)
-        event.create("overgrown_bacterial_dna")
+    event.create("overgrown_bacterial_dna")
         .liquid()
         .color(0x95f5d0)
-        event.create("panaeolus_cyanescens")
+    event.create("panaeolus_cyanescens")
         .liquid()
         .color(0x3a5963)
-        event.create("streptomyces_coelicolor")
+    event.create("streptomyces_coelicolor")
         .liquid()
         .color(0x3a6353)
-        event.create("pcr_its1_its2")
+    event.create("pcr_its1_its2")
         .liquid()
         .color(0xdb393e)
-        event.create("streptomyces_peucetius")
+    event.create("streptomyces_peucetius")
         .liquid()
         .color(0xdb3962)
-        event.create("taq_polymerase")
+    event.create("taq_polymerase")
         .liquid()
         .color(0x082b06)
-        event.create("doxorubicin")
+    event.create("doxorubicin")
         .liquid()
         .color(0x062b18)
-        event.create("phage")
+    event.create("phage")
         .liquid()
         .color(0x148f50)
-        event.create("bacterium")
+    event.create("bacterium")
         .liquid()
         .color(0xe310b9)
-        event.create("bacterial_dna")
+    event.create("bacterial_dna")
         .liquid()
         .color(0xff0066)
-        event.create("mycena_hypsizyga")
+    event.create("mycena_hypsizyga")
         .liquid()
         .color(0x00ff11)
-        event.create("stropharic_hypoxylon")
+    event.create("stropharic_hypoxylon")
         .liquid()
         .color(0x7a64f5)
-        event.create("hypoxylon")
+    event.create("hypoxylon")
         .liquid().ingot()
         .color(0x7c65fc)
         .element('hypoxylon')
         .iconSet('bright')
-        .cableProperties(GTValues.V[GTValues.UXV], 64, 2, true)
-        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_GEAR, GTMaterialFlags.GENERATE_FINE_WIRE, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_DENSE, GTMaterialFlags.GENERATE_ROTOR, GTMaterialFlags.GENERATE_BOLT_SCREW, GTMaterialFlags.NO_SMELTING, GTMaterialFlags.NO_ORE_SMELTING)
-    
+        .cableProperties(GTValues.V[GTValues.UXV], 256, 0, true)
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_GEAR,
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.GENERATE_FRAME,
+            GTMaterialFlags.GENERATE_DENSE,
+            GTMaterialFlags.GENERATE_ROTOR,
+            GTMaterialFlags.GENERATE_BOLT_SCREW,
+            GTMaterialFlags.NO_SMELTING,
+            GTMaterialFlags.NO_ORE_SMELTING
+        );
     event.create('draconium')
         .ingot().liquid()
         .ore(1, 1,)
@@ -591,11 +713,10 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
             GTMaterialFlags.GENERATE_SMALL_GEAR,
             GTMaterialFlags.GENERATE_LONG_ROD,
             GTMaterialFlags.GENERATE_LENS,
-            GTMaterialFlags.GENERATE_ROUND,
+            GTMaterialFlags.GENERATE_ROUND
         )
         .blastTemp(13000, 'highest', 2097152, 200)
         .cableProperties(GTValues.V[GTValues.UEV], 8, 4, false)
-    
     event.create('awakened_draconium')
         .ingot().liquid()
         .ore(1, 1,)
@@ -613,7 +734,9 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
             GTMaterialFlags.GENERATE_BOLT_SCREW,
             GTMaterialFlags.GENERATE_SMALL_GEAR,
             GTMaterialFlags.GENERATE_LONG_ROD,
-            GTMaterialFlags.GENERATE_ROUND
+            GTMaterialFlags.GENERATE_ROUND,
+            GTMaterialFlags.GENERATE_SPRING,
+            GTMaterialFlags.GENERATE_SPRING_SMALL
         )
         .blastTemp(15000, 'highest', 134217728, 3400)
         .cableProperties(GTValues.V[GTValues.UIV], 32, 4, false)
@@ -624,7 +747,10 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .formula('Cf₁₉(Si(Ir₁₉Os₈(Nc(Cr₇Nt₄)₈)(PbR(Pb₆Pt₂Rn₁))₁)₈)', true)
         .color(0xa0b0bd).secondaryColor(0x232020)
         .iconSet('radioactive')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION, GTMaterialFlags.GENERATE_DENSE)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION,
+            GTMaterialFlags.GENERATE_DENSE
+        );
     event.create('stabilized_iridium')
         .ingot().liquid()
         .components('19x iridium', '8x osmium', '56x chromium', '36x neutronium', '6x lead', '2x platinum', '1x radon')
@@ -632,7 +758,12 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .color(0x9deafa).secondaryColor(0x232020)
         .iconSet('radioactive')
         .blastTemp(13000, 'highest', 2097152, 200)
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION, GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_GEAR)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION,
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_GEAR
+        );
     event.create('magnetic_stabilized_iridium')
         .ingot()
         .formula('Ir₁₉Os₈(Nc(Cr₇Nt₄)₈)(PbR(Pb₆Pt₂Rn))₁)', true)
@@ -641,8 +772,10 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .ingotSmeltInto(GTMaterials.get('stabilized_iridium'))
         .arcSmeltInto(GTMaterials.get('stabilized_iridium'))
         .macerateInto(GTMaterials.get('stabilized_iridium'))
-        .flags(GTMaterialFlags.GENERATE_LONG_ROD, GTMaterialFlags.IS_MAGNETIC)
-
+        .flags(
+            GTMaterialFlags.GENERATE_LONG_ROD,
+            GTMaterialFlags.IS_MAGNETIC
+        );
     event.create('neutronic_chromite')
         .ingot()
         .components('7x chromium', '4x neutronium')
@@ -650,7 +783,9 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .color(0xf5c6da).secondaryColor(0x232020)
         .iconSet('radioactive')
         .blastTemp(10500, 'highest', 524288, 900)
-        .flags(GTMaterialFlags.GENERATE_PLATE)
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE
+        );
     event.create('radium_infused_lead')
         .ingot()
         .components('6x lead', '2x platinum', '1x radon')
@@ -658,22 +793,37 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .color(0x52303e)
         .iconSet('shiny')
         .blastTemp(3500, 'highest', 2048, 900)
-        .flags(GTMaterialFlags.GENERATE_PLATE)
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE
+        );
     event.create('chaos')
         .gem().liquid()
         .ore(1, 1,)
         .element('chaos')
-        .cableProperties(GTValues.V[GTValues.UIV], 512, 0, true)
+        .cableProperties(GTValues.V[GTValues.UIV], 256, 0, true)
         .color(0x010005)
         .iconSet('dull')
-        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_LENS, GTMaterialFlags.GENERATE_DENSE)
-/// P O L Y M E R   S T U F F
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_LENS,
+            GTMaterialFlags.GENERATE_DENSE
+        );
+
+
+    /// P O L Y M E R   S T U F F
 
     event.create('neoprene')
         .liquid(313).ingot().polymer()
         .color(0xFFECB3)
         .components('4x carbon', '5x hydrogen', '1x chlorine')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION, GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.GENERATE_RING, GTMaterialFlags.NO_SMELTING)  
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION,
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_FOIL,
+            GTMaterialFlags.GENERATE_RING,
+            GTMaterialFlags.NO_SMELTING
+        )
         .iconSet('bright')
     event.create('xlpe')
         .liquid(408).ingot().polymer()
@@ -681,34 +831,71 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .components('2x carbon', '4x hydrogen')
         .formula("(C₂H₄)↔", true)
         .iconSet('bright')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION, GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.GENERATE_RING)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION,
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_FOIL,
+            GTMaterialFlags.GENERATE_RING
+        );
     event.create('peek')
         .liquid(408).ingot().polymer()
         .color(0x382e27)
         .components('19x carbon', '12x hydrogen', '3x oxygen')
         .iconSet('bright')
         .fluidPipeProperties(616, 50000, true, true, true, false)
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION, GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.GENERATE_RING, GTMaterialFlags.GENERATE_FRAME)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION,
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_FOIL,
+            GTMaterialFlags.GENERATE_RING,
+            GTMaterialFlags.GENERATE_FRAME
+        );
     event.create('carbon_nanotubes')
         .ingot()
         .color(0x050505)
         .components('64x carbon')
         .formula("C⁺", true)
         .iconSet('bright')
-        .flags(GTMaterialFlags.NO_SMELTING, GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.GENERATE_FINE_WIRE)
+        .flags(
+            GTMaterialFlags.NO_SMELTING,
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_FOIL,
+            GTMaterialFlags.GENERATE_FINE_WIRE
+        );
     event.create('kevlar')
         .ingot()
         .color(0xd7d952)
         .components('14x carbon', '10x hydrogen', '2x nitrogen', '2x oxygen')
         .iconSet('dull')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION, GTMaterialFlags.NO_SMELTING, GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.GENERATE_RING, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_DENSE, GTMaterialFlags.GENERATE_FINE_WIRE)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION,
+            GTMaterialFlags.NO_SMELTING,
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_FOIL,
+            GTMaterialFlags.GENERATE_RING,
+            GTMaterialFlags.GENERATE_FRAME,
+            GTMaterialFlags.GENERATE_DENSE,
+            GTMaterialFlags.GENERATE_FINE_WIRE
+        );
     event.create('zylon')
         .ingot()
         .color(0xd1a72a)
         .components('14x carbon', '6x hydrogen', '2x nitrogen', '2x oxygen')
         .iconSet('bright')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION, GTMaterialFlags.NO_SMELTING, GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.GENERATE_RING, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_DENSE, GTMaterialFlags.GENERATE_FINE_WIRE)
-
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION,
+            GTMaterialFlags.NO_SMELTING,
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_FOIL,
+            GTMaterialFlags.GENERATE_RING,
+            GTMaterialFlags.GENERATE_FRAME,
+            GTMaterialFlags.GENERATE_DENSE,
+            GTMaterialFlags.GENERATE_FINE_WIRE
+        );
 	event.create('sbr_emulsion')
 		.liquid(353)
 		.color(0xFFECB3)
@@ -717,7 +904,9 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
 		.liquid(305) 
 		.color(0xF5F5F5)
 		.components('1x silicon', '1x hydrogen', '3x chlorine')
-        .flags(GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING)
+        .flags(
+            GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING
+        );
 	event.create('pure_trichlorosilane')
 		.liquid(305) 
 		.color(0xFFFFFF)
@@ -750,32 +939,44 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .dust()
         .color(0xDEDEDE)
         .components('2x carbon', '3x hydrogen', '1x sodium', '2x oxygen')
-        .flags(GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING)
+        .flags(
+            GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING
+        );
     event.create('calcium_carbide')
         .dust()
         .color(0x6b6a66)
         .components('1x calcium', '2x carbon')
-        .flags(GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING)
+        .flags(
+            GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING
+        );
     event.create('acetylene')
         .gas(467)
         .color(0xabaaa7)
         .components('2x carbon', '2x hydrogen')
-        .flags(GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING)
+        .flags(
+            GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING
+        );
     event.create('cuprous_chloride')
         .dust()
         .color(0x4A3C78)
         .components('1x copper', '1x chlorine')
-        .flags(GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING)
+        .flags(
+            GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING
+        );
     event.create('vinylacetylene')
         .liquid(273)
         .color(0xFFAB91)
         .components('4x carbon', '4x hydrogen')
-        .flags(GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING)
+        .flags(
+            GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING
+        );
     event.create('chloroprene')
         .liquid(332)
         .color(0xFFCC80)
         .components('4x carbon', '5x hydrogen', '1x chlorine')
-        .flags(GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING)
+        .flags(
+            GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING
+        );
     event.create('neoprene_latex')
         .liquid(313) 
         .color(0xc2b17e)
@@ -788,12 +989,16 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .liquid(388)
         .color(0xFFF59D)
         .components('9x carbon', '12x hydrogen', '2x oxygen')
-        .flags(GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING)
+        .flags(
+            GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING
+        );
     event.create('dicumyl_peroxide')
         .liquid(353)
         .color(0xF5F5F5)
         .components('18x carbon', '22x hydrogen', '2x oxygen')
-        .flags(GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING)
+        .flags(
+            GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING
+        );
     event.create('pe_peroxide_mixture')
         .liquid(473)
         .color(0xE0E0E0)
@@ -802,17 +1007,24 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .ingot()
         .color(0xE0E0E0)
         .components('4x carbon', '2x hydrogen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION, GTMaterialFlags.GENERATE_PLATE)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION,
+            GTMaterialFlags.GENERATE_PLATE
+        );
     event.create('antimony_pentafluoride')
         .dust()
         .color(0xE6E6FA)
         .components('1x antimony', '5x fluorine')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('aluminium_chloride')
         .dust()
         .color(0xE6E6FA)
         .components('1x aluminium', '3x chlorine')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('fluorobenzene')
         .liquid(358)
         .color(0xFFFF00)
@@ -825,17 +1037,23 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .liquid(349)
         .color(0xFFFFE0)
         .components('1x sulfur', '1x oxygen', '2x chlorine')
-        .flags(GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING)
+        .flags(
+            GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING
+        );
     event.create('benzenesulfonic_acid')
         .dust()
         .color(0xE6E6FA)
         .components('6x carbon', '6x hydrogen', '3x oxygen', '1x sulfur')
-        .flags(GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING)
+        .flags(
+            GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING
+        );
     event.create('benzenesulfonyl_chloride')
         .liquid(291)
         .color(0xffff7a)
         .components('6x carbon', '5x hydrogen', '1x chlorine', '2x oxygen', '1x sulfur')
-        .flags(GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING)
+        .flags(
+            GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING
+        );
     event.create('diphenyl_sulfone')
         .liquid(428) 
         .color(0xF5F5F5)
@@ -849,12 +1067,16 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .liquid(593)
         .color(0xFFFF00)
         .components('13x carbon', '8x hydrogen', '2x fluorine', '1x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('purified_difluorobenzophenone')
         .dust()
         .color(0xFFEB3B)
         .components('13x carbon', '8x hydrogen', '2x fluorine', '1x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('iron_sulfate')
         .dust()
         .color(0x94d490)
@@ -896,17 +1118,23 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .liquid(249)
         .color(0xc0c299)
         .components('5x carbon', '9x hydrogen', '1x nitrogen', '1x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('raw_peek_solution')
         .liquid(593)
         .color(0x382a1f)
         .components('19x carbon', '12x hydrogen', '3x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('raw_peek')
         .dust()
         .color(0x382a1f)
         .components('19x carbon', '12x hydrogen', '3x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('enriched_carbon_slurry')
         .liquid(4600)
         .color(0x050505)
@@ -926,7 +1154,11 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
     event.create('wet_carbon_nanotubes')
         .dust()
         .color(0x0f0f0f)
-        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_FOIL, GTMaterialFlags.DISABLE_MATERIAL_RECIPES)
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_FOIL,
+            GTMaterialFlags.DISABLE_MATERIAL_RECIPES
+        );
     event.create('deep_water')
         .liquid(300)
         .color(0x01076e)
@@ -972,7 +1204,9 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .color(0x1152a8)
         .components('2x aluminium', '4x oxygen', '1x cobalt')
         .formula('CoO·Al₂O₃', true)
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('activated_cobalt_alumina_catalyst')
         .dust()
         .color(0x4a7f96)
@@ -998,17 +1232,23 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .liquid(322) 
         .color(0xFFECB3)
         .components('3x carbon', '6x hydrogen', '1x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('propionic_acid')
         .liquid(414) 
         .color(0xF5F5F5)
         .components('3x carbon', '6x hydrogen', '2x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('propylamine')
         .liquid(321)
         .color(0xE1F5FE)
         .components('3x carbon', '9x hydrogen', '1x nitrogen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('sodium_cyanide')
         .dust()
         .color(0xe8e8e8)
@@ -1030,12 +1270,16 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .dust()
         .color(0xd0d1cd)
         .components('8x carbon', '12x hydrogen', '4x nitrogen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION) 
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        ); 
     event.create('tripropylamine')
         .liquid(403) 
         .color(0xF3E5F5)
         .components('9x carbon', '21x hydrogen', '1x nitrogen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('hydrogen_bromide')
         .gas(206)
         .color(0xeb823d)
@@ -1044,7 +1288,9 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .liquid(344)
         .color(0xFFCC80)
         .components('3x carbon', '7x hydrogen', '1x bromine')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('tetrapropylammonium_bromide_solution')
         .liquid(344)
         .color(0x99914e)
@@ -1062,12 +1308,16 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .liquid(325)
         .color(0xab7055)
         .components('2x carbon', '6x hydrogen', '1x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('sodium_aluminate')
         .dust()
         .color(0xf7f5bc)
         .components('1x sodium', '1x aluminium', '2x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('zsm_5_solution')
         .liquid(325)
         .color(0x66853e)
@@ -1090,7 +1340,9 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .liquid(312)
         .color(0xFFF8DC)
         .components('5x carbon', '6x hydrogen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('sodium_hypochlorite')
         .dust()
         .color(0xdedad1)
@@ -1099,12 +1351,16 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .liquid(305)
         .color(0x804541)
         .components('5x carbon', '2x hydrogen', '8x chlorine')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('hexachlorocyclopentadiene')
         .liquid(305)
         .color(0xe9eb7f)
         .components('5x carbon', '6x chlorine')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('endosulfate')
         .dust()
         .color(0x4a391d)
@@ -1162,7 +1418,9 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .dust()
         .color(0xecf5e6)
         .components('8x carbon', '6x hydrogen', '4x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('terephthalic_acid')
         .dust()
         .color(0xF5F5F5)
@@ -1171,7 +1429,9 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .liquid(536) 
         .color(0xFFF59D)
         .components('8x carbon', '4x hydrogen', '2x chlorine', '2x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('copper_sulfate')
         .dust() 
         .color(0x2828d1)
@@ -1193,32 +1453,44 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .dust() 
         .color(0xd4af5f)
         .components('6x carbon', '6x hydrogen', '2x nitrogen', '2x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)    
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );    
     event.create('p_phenylenediamine_solution')
         .liquid(413)
         .color(0x4A148C)
         .components('6x carbon', '8x hydrogen', '2x nitrogen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)   
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );   
     event.create('p_phenylenediamine')
         .liquid(413)
         .color(0x5409b0)
         .components('6x carbon', '8x hydrogen', '2x nitrogen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)   
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );   
     event.create('kevlar_polymer_solution')
         .liquid(278)
         .color(0x7B1FA2)
         .components('14x carbon', '10x hydrogen', '2x nitrogen', '2x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('degassed_kevlar_solution')
         .liquid(273)
         .color(0x7B1FA2)
         .components('14x carbon', '10x hydrogen', '2x nitrogen', '2x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)   
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );   
     event.create('meta_stable_molten_kevlar')
         .liquid(666)
         .color(0xd6d93d)
         .components('14x carbon', '10x hydrogen', '2x nitrogen', '2x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)   
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );   
     event.create('triethylaluminium')
         .liquid(390)
         .color(0x807745)
@@ -1249,12 +1521,16 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .dust()
         .color(0xdbce9c)
         .components('18x carbon', '36x hydrogen', '2x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)  
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );  
     event.create('oleic_acid')
         .liquid()
         .color(0xb8c991)
         .components('18x carbon', '34x hydrogen', '2x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('plasmacracked_coal_tar')
         .liquid(323)
         .color(0x1f1f1f)
@@ -1269,12 +1545,16 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .liquid(383)
         .color(0xE0E0E0)
         .components('5x carbon', '5x hydrogen', '1x nitrogen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('acetaldehyde')
         .gas(297)
         .color(0x9e4c4c)
         .components('2x carbon', '4x hydrogen', '1x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('synthetic_pyridine_mixture')
         .liquid(354)
         .color(0xbf8d49)
@@ -1282,17 +1562,23 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .liquid(383)
         .color(0xcfc7bc)
         .components('5x carbon', '5x hydrogen', '1x nitrogen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
      event.create('technical_pyridine_mixture')
         .liquid(473)
         .color(0xFFECB3)
         .components('5x carbon', '5x hydrogen', '1x nitrogen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('dry_technical_pyridine')
         .liquid(393)
         .color(0xBCAAA4)
         .components('5x carbon', '5x hydrogen', '1x nitrogen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('water_toluene_azeotrope')
         .liquid(393)
         .color(0x5e2b2b)
@@ -1300,7 +1586,9 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .liquid(388)
         .color(0x9E9E9E)
         .components('5x carbon', '5x hydrogen', '1x nitrogen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('picoline')
         .dust()
         .color(0xa8d15c)
@@ -1320,22 +1608,30 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .liquid()
         .color(0xb8420b)
         .components('4x carbon', '10x hydrogen', '1x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('dichloropyridine')
         .dust()
         .color(0xbdafa6)
         .components('5x carbon', '3x hydrogen', '2x chlorine', '1x nitrogen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('2-6_bischloromagnesiopyridine')
         .liquid()
         .color(0xF0E68C)
         .components('5x carbon', '3x hydrogen', '2x chlorine', '2x magnesium', '1x nitrogen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('magnesium_pyridine_2-6_dicarboxylate')
         .dust()
         .color(0xc7c4a9)
         .components('7x carbon', '3x hydrogen', '1x magnesium', '1x nitrogen', '4x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('picolinic_acid_slurry')
         .liquid()
         .color(0x8e5999)
@@ -1371,7 +1667,9 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .liquid()
         .color(0xbf9c71)
         .components('6x carbon', '3x hydrogen', '2x chlorine', '1x nitrogen', '2x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('dipicolinyl_dichloride')
         .dust()
         .color(0xdbbf9c)
@@ -1423,24 +1721,33 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .liquid(453)
         .color(0x7B1FA2)
         .components('14x carbon', '6x hydrogen', '2x nitrogen', '2x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('degassed_zylon_solution')
         .liquid(429)
         .color(0xc96ef0)
         .components('14x carbon', '6x hydrogen', '2x nitrogen', '2x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('treated_zylon_polymer_solution')
         .liquid(444)
         .color(0xc2a634)
         .components('14x carbon', '6x hydrogen', '2x nitrogen', '2x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('meta_stable_molten_zylon')
         .liquid(666)
         .color(0xd1af24)
         .components('14x carbon', '6x hydrogen', '2x nitrogen', '2x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
 
-/// P C B Stuff
+
+    /// P C B Stuff
 
     event.create('nano_diamond')
         .gem()
@@ -1489,7 +1796,9 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .formula('Cn⇄')
         .iconSet('opal')
         .color(0x4de8de)
-        .flags(GTMaterialFlags.GENERATE_LENS)
+        .flags(
+            GTMaterialFlags.GENERATE_LENS
+        );
     event.create('silicon_tetrachloride')
         .liquid(330)
         .color(0x9d82b8)
@@ -1502,7 +1811,9 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .liquid(483)
         .color(0xc1ced6)
         .components('1x silver', '1x nitrogen', '3x oxygen')
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('nanoreinforced_silver')
         .dust()
         .color(0xa3a29d)
@@ -1517,7 +1828,9 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .dust()
         .color(0x857999)
         .components('1x sodium', '1x iodine', '3x oxygen')
-        .flags(GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING)
+        .flags(
+            GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING
+        );
     event.create('thallium_iodine')
         .dust()
         .color(0xfcf03d)
@@ -1527,7 +1840,10 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .color(0x585163)
         .components('1x sodium', '1x iodine', '1x thallium')
         .formula('NaI(Tl)', true)
-        .flags(GTMaterialFlags.GENERATE_LENS, GTMaterialFlags.DISABLE_DECOMPOSITION)  
+        .flags(
+            GTMaterialFlags.GENERATE_LENS,
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );  
     event.create('tachyon_condensate')
         .liquid(10)
         .color(0xb519ad)
@@ -1555,304 +1871,293 @@ GTMaterials.Thallium.setProperty(PropertyKey.INGOT, new $IngotProperty());
         .color(0xdb5a96)
 
 
-
-
-
-
-
-
-
-/// C O S M I C   M A T E R I A L S   F U S I O N
+    /// C O S M I C   M A T E R I A L S   F U S I O N
     
-event.create('cosmic_tungsten')
-.ingot().liquid()
-.ore(1, 1,)
-.element('cosmic_tungsten')
-.color(0x04011c)
-.iconSet('radioactive')
-.blastTemp(13000, 'highest', 8388608, 900)
-.flags(
-    GTMaterialFlags.GENERATE_PLATE, 
-    GTMaterialFlags.GENERATE_ROD, 
-    GTMaterialFlags.GENERATE_GEAR, 
-    GTMaterialFlags.GENERATE_FINE_WIRE,
-    GTMaterialFlags.GENERATE_FRAME, 
-    GTMaterialFlags.GENERATE_DENSE, 
-    GTMaterialFlags.GENERATE_ROTOR, 
-    GTMaterialFlags.GENERATE_BOLT_SCREW,
-    GTMaterialFlags.GENERATE_SMALL_GEAR,
-    GTMaterialFlags.GENERATE_LONG_ROD,
-    GTMaterialFlags.GENERATE_ROUND
-)
-event.create('cosmic_titanium')
-.ingot().liquid()
-.ore(1, 1,)
-.element('cosmic_titanium')
-.color(0x3d0245)
-.iconSet('radioactive')
-.blastTemp(13000, 'highest', 8388608, 900)
-.flags(
-    GTMaterialFlags.GENERATE_PLATE, 
-    GTMaterialFlags.GENERATE_ROD, 
-    GTMaterialFlags.GENERATE_GEAR, 
-    GTMaterialFlags.GENERATE_FINE_WIRE,
-    GTMaterialFlags.GENERATE_FRAME, 
-    GTMaterialFlags.GENERATE_DENSE, 
-    GTMaterialFlags.GENERATE_ROTOR, 
-    GTMaterialFlags.GENERATE_BOLT_SCREW,
-    GTMaterialFlags.GENERATE_SMALL_GEAR,
-    GTMaterialFlags.GENERATE_ROUND,
-    GTMaterialFlags.GENERATE_LONG_ROD
-)
-event.create('cosmic_iridium')
-.ingot().liquid()
-.ore(1, 1,)
-.element('cosmic_iridium')
-.color(0x016646)
-.iconSet('radioactive')
-.blastTemp(13000, 'highest', 33554432, 900)
-.flags(
-    GTMaterialFlags.GENERATE_PLATE, 
-    GTMaterialFlags.GENERATE_ROD, 
-    GTMaterialFlags.GENERATE_GEAR, 
-    GTMaterialFlags.GENERATE_FINE_WIRE,
-    GTMaterialFlags.GENERATE_FRAME, 
-    GTMaterialFlags.GENERATE_DENSE, 
-    GTMaterialFlags.GENERATE_ROTOR, 
-    GTMaterialFlags.GENERATE_BOLT_SCREW,
-    GTMaterialFlags.GENERATE_SMALL_GEAR,
-    GTMaterialFlags.GENERATE_ROUND,
-    GTMaterialFlags.GENERATE_LONG_ROD
-)
-event.create('cosmic_osmium')
-.ingot().liquid()
-.ore(1, 1,)
-.element('cosmic_osmium')
-.color(0x023e45)
-.iconSet('radioactive')
-.blastTemp(13000, 'highest', 8388608, 900)
-.flags(
-    GTMaterialFlags.GENERATE_PLATE, 
-    GTMaterialFlags.GENERATE_ROD, 
-    GTMaterialFlags.GENERATE_GEAR, 
-    GTMaterialFlags.GENERATE_FINE_WIRE,
-    GTMaterialFlags.GENERATE_FRAME, 
-    GTMaterialFlags.GENERATE_DENSE, 
-    GTMaterialFlags.GENERATE_ROTOR, 
-    GTMaterialFlags.GENERATE_BOLT_SCREW,
-    GTMaterialFlags.GENERATE_LONG_ROD,
-    GTMaterialFlags.GENERATE_SMALL_GEAR,
-    GTMaterialFlags.GENERATE_ROUND
-)
+    event.create('cosmic_tungsten')
+        .ingot().liquid()
+        .ore(1, 1,)
+        .element('cosmic_tungsten')
+        .color(0x04011c)
+        .iconSet('radioactive')
+        .blastTemp(13000, 'highest', 8388608, 900)
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE, 
+            GTMaterialFlags.GENERATE_ROD, 
+            GTMaterialFlags.GENERATE_GEAR, 
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.GENERATE_FRAME, 
+            GTMaterialFlags.GENERATE_DENSE, 
+            GTMaterialFlags.GENERATE_ROTOR, 
+            GTMaterialFlags.GENERATE_BOLT_SCREW,
+            GTMaterialFlags.GENERATE_SMALL_GEAR,
+            GTMaterialFlags.GENERATE_LONG_ROD,
+            GTMaterialFlags.GENERATE_ROUND
+        );
+    event.create('cosmic_titanium')
+        .ingot().liquid()
+        .ore(1, 1,)
+        .element('cosmic_titanium')
+        .color(0x3d0245)
+        .iconSet('radioactive')
+        .blastTemp(13000, 'highest', 8388608, 900)
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE, 
+            GTMaterialFlags.GENERATE_ROD, 
+            GTMaterialFlags.GENERATE_GEAR, 
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.GENERATE_FRAME, 
+            GTMaterialFlags.GENERATE_DENSE, 
+            GTMaterialFlags.GENERATE_ROTOR, 
+            GTMaterialFlags.GENERATE_BOLT_SCREW,
+            GTMaterialFlags.GENERATE_SMALL_GEAR,
+            GTMaterialFlags.GENERATE_ROUND,
+            GTMaterialFlags.GENERATE_LONG_ROD
+        );
+    event.create('cosmic_iridium')
+        .ingot().liquid()
+        .ore(1, 1,)
+        .element('cosmic_iridium')
+        .color(0x016646)
+        .iconSet('radioactive')
+        .blastTemp(13000, 'highest', 33554432, 900)
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE, 
+            GTMaterialFlags.GENERATE_ROD, 
+            GTMaterialFlags.GENERATE_GEAR, 
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.GENERATE_FRAME, 
+            GTMaterialFlags.GENERATE_DENSE, 
+            GTMaterialFlags.GENERATE_ROTOR, 
+            GTMaterialFlags.GENERATE_BOLT_SCREW,
+            GTMaterialFlags.GENERATE_SMALL_GEAR,
+            GTMaterialFlags.GENERATE_ROUND,
+            GTMaterialFlags.GENERATE_LONG_ROD
+        );
+    event.create('cosmic_osmium')
+        .ingot().liquid()
+        .ore(1, 1,)
+        .element('cosmic_osmium')
+        .color(0x023e45)
+        .iconSet('radioactive')
+        .blastTemp(13000, 'highest', 8388608, 900)
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE, 
+            GTMaterialFlags.GENERATE_ROD, 
+            GTMaterialFlags.GENERATE_GEAR, 
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.GENERATE_FRAME, 
+            GTMaterialFlags.GENERATE_DENSE, 
+            GTMaterialFlags.GENERATE_ROTOR, 
+            GTMaterialFlags.GENERATE_BOLT_SCREW,
+            GTMaterialFlags.GENERATE_LONG_ROD,
+            GTMaterialFlags.GENERATE_SMALL_GEAR,
+            GTMaterialFlags.GENERATE_ROUND
+        );
+    event.create("universium")
+        .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
+        .ingot()
+        .element(GTElements.get("universium"))
+        .color(0xffffff)
+        .iconSet('universium')
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE, 
+            GTMaterialFlags.GENERATE_ROD, 
+            GTMaterialFlags.GENERATE_GEAR, 
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.GENERATE_DENSE, 
+            GTMaterialFlags.GENERATE_ROTOR, 
+            GTMaterialFlags.GENERATE_BOLT_SCREW,
+            GTMaterialFlags.GENERATE_SMALL_GEAR,
+            GTMaterialFlags.GENERATE_ROUND,
+            GTMaterialFlags.GENERATE_SPRING,
+            GTMaterialFlags.GENERATE_FRAME
+        );
+    event.create("eternity")
+        .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
+        .ingot()
+        .element(GTElements.get("eternity"))
+        .color(0xffffff)
+        .iconSet('eternity')
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE, 
+            GTMaterialFlags.GENERATE_ROD, 
+            GTMaterialFlags.GENERATE_GEAR, 
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.GENERATE_DENSE, 
+            GTMaterialFlags.GENERATE_ROTOR, 
+            GTMaterialFlags.GENERATE_BOLT_SCREW,
+            GTMaterialFlags.GENERATE_SMALL_GEAR,
+            GTMaterialFlags.GENERATE_ROUND,
+            GTMaterialFlags.GENERATE_SPRING,
+            GTMaterialFlags.GENERATE_FRAME
+        );
+    event.create("molten_space_time")
+        .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
+        .color(0xffffff)
+    event.create('space_time')
+        .ingot()
+        .element('space_time')
+        .color(0xffffff)
+        .iconSet('space_time')
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_LONG_ROD,
+            GTMaterialFlags.GENERATE_RING,
+            GTMaterialFlags.GENERATE_ROUND,
+            GTMaterialFlags.GENERATE_GEAR, 
+            GTMaterialFlags.GENERATE_SMALL_GEAR,
+            GTMaterialFlags.GENERATE_SPRING, 
+            GTMaterialFlags.GENERATE_BOLT_SCREW, 
+            GTMaterialFlags.PHOSPHORESCENT
+        );
+    event.create("stellar_matter_plasma")
+        .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
+        .ingot()
+        .element(GTElements.get("stellar_matter_plasma"))
+        .color(0xffffff)
+        .iconSet('stellar_matter')
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE, 
+            GTMaterialFlags.GENERATE_ROD, 
+            GTMaterialFlags.GENERATE_GEAR, 
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.GENERATE_DENSE, 
+            GTMaterialFlags.GENERATE_ROTOR, 
+            GTMaterialFlags.GENERATE_BOLT_SCREW,
+            GTMaterialFlags.GENERATE_SMALL_GEAR,
+            GTMaterialFlags.GENERATE_ROUND,
+            GTMaterialFlags.GENERATE_SPRING,
+            GTMaterialFlags.GENERATE_FRAME
+        );
 
 
-event.create("universium")
-.liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
-.ingot()
-.element(GTElements.get("universium"))
-.color(0xffffff)
-.iconSet('universium')
-.flags(
-    GTMaterialFlags.GENERATE_PLATE, 
-    GTMaterialFlags.GENERATE_ROD, 
-    GTMaterialFlags.GENERATE_GEAR, 
-    GTMaterialFlags.GENERATE_FINE_WIRE,
-    GTMaterialFlags.GENERATE_DENSE, 
-    GTMaterialFlags.GENERATE_ROTOR, 
-    GTMaterialFlags.GENERATE_BOLT_SCREW,
-    GTMaterialFlags.GENERATE_SMALL_GEAR,
-    GTMaterialFlags.GENERATE_ROUND,
-    GTMaterialFlags.GENERATE_SPRING,
-    GTMaterialFlags.GENERATE_FRAME
-)
-event.create("eternity")
-.liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
-.ingot()
-.element(GTElements.get("eternity"))
-.color(0xffffff)
-.iconSet('eternity')
-.flags(
-    GTMaterialFlags.GENERATE_PLATE, 
-    GTMaterialFlags.GENERATE_ROD, 
-    GTMaterialFlags.GENERATE_GEAR, 
-    GTMaterialFlags.GENERATE_FINE_WIRE,
-    GTMaterialFlags.GENERATE_DENSE, 
-    GTMaterialFlags.GENERATE_ROTOR, 
-    GTMaterialFlags.GENERATE_BOLT_SCREW,
-    GTMaterialFlags.GENERATE_SMALL_GEAR,
-    GTMaterialFlags.GENERATE_ROUND,
-    GTMaterialFlags.GENERATE_SPRING,
-    GTMaterialFlags.GENERATE_FRAME
-)
-event.create("molten_space_time")
-.liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
-.color(0xffffff)
-event.create('space_time')
-.ingot()
-.element('space_time')
-.color(0xffffff)
-.iconSet('space_time')
-.flags(
-    GTMaterialFlags.GENERATE_PLATE,
-    GTMaterialFlags.GENERATE_ROD,
-    GTMaterialFlags.GENERATE_LONG_ROD,
-    GTMaterialFlags.GENERATE_RING,
-    GTMaterialFlags.GENERATE_ROUND,
-    GTMaterialFlags.GENERATE_GEAR, 
-    GTMaterialFlags.GENERATE_SMALL_GEAR,
-    GTMaterialFlags.GENERATE_SPRING, 
-    GTMaterialFlags.GENERATE_BOLT_SCREW, 
-    GTMaterialFlags.PHOSPHORESCENT
-)
+    // COSMIC LINE
 
-event.create("stellar_matter_plasma")
-.liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
-.ingot()
-.element(GTElements.get("stellar_matter_plasma"))
-.color(0xffffff)
-.iconSet('stellar_matter')
-.flags(
-    GTMaterialFlags.GENERATE_PLATE, 
-    GTMaterialFlags.GENERATE_ROD, 
-    GTMaterialFlags.GENERATE_GEAR, 
-    GTMaterialFlags.GENERATE_FINE_WIRE,
-    GTMaterialFlags.GENERATE_DENSE, 
-    GTMaterialFlags.GENERATE_ROTOR, 
-    GTMaterialFlags.GENERATE_BOLT_SCREW,
-    GTMaterialFlags.GENERATE_SMALL_GEAR,
-    GTMaterialFlags.GENERATE_ROUND,
-    GTMaterialFlags.GENERATE_SPRING,
-    GTMaterialFlags.GENERATE_FRAME
-
-)
+    event.create("raw_cosmic_matter")
+        .gas()
+        .color(0x000000)
+    event.create("crude_astral_flux")
+        .plasma()
+        .color(0x2c00ad)
+    event.create("astral_flux") 
+        .plasma()
+        .color(0x4000ff)
+        .element('astral_flux')
+    event.create("hyper_ionized_helium")
+        .plasma()
+        .color(0xfff2ab)
+        .formula('He⁺', true)
+    event.create("infused_cosmic_matter")
+        .gas()
+        .color(0xaeabff)
+    event.create("stabilized_raw_cosmic_matter")
+        .gas()
+        .color(0x14004f)
+    event.create("cryo_compressed_raw_cosmic_matter")
+        .gas()
+        .color(0x00224f)
+    event.create("cryogenic_neutron_flow")
+        .liquid()
+        .color(0x00fff7)
+    event.create("shifted_cosmic_matter_base")
+        .gas()
+        .color(0x020078)
+    event.create("plasma_tempered_cosmic_matter_base")
+        .plasma()
+        .color(0x060040)
+    event.create("hyper_dense_cosmic_matter_base")
+        .plasma()
+        .color(0x020012)
+    event.create("refined_cosmic_matter")
+        .plasma()
+        .color(0x1c00ff)
+    event.create("cosmic_matter")
+        .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
+        .element(GTElements.get("cosmic_matter"))
+        .color(0xffffff)
+    event.create("pure_cosmic_matter")
+        .ingot()
+        .element(GTElements.get("cosmic_matter"))
+        .color(0xffffff)
+        .iconSet('cosmic_matter')
+        .flags(
+            GTMaterialFlags.GENERATE_PLATE, 
+            GTMaterialFlags.GENERATE_ROD, 
+            GTMaterialFlags.GENERATE_GEAR, 
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.GENERATE_DENSE, 
+            GTMaterialFlags.GENERATE_ROTOR, 
+            GTMaterialFlags.GENERATE_BOLT_SCREW,
+            GTMaterialFlags.GENERATE_SMALL_GEAR,
+            GTMaterialFlags.GENERATE_ROUND,
+            GTMaterialFlags.GENERATE_SPRING,
+            GTMaterialFlags.GENERATE_FRAME
+        );
 
 
+    // PLASMAS NEBULA
 
-// COSMIC LINE
+    event.create("hypercharged_nebular") 
+        .plasma()
+        .color(0x1c03fc)
+        .element('nebular_matter')
+    event.create("high_entropy_neptunium") 
+        .plasma()
+        .color(0x03a1fc)
+        .element(GTElements.Np)
+    event.create("supercritical_californium") 
+        .plasma()
+        .color(0xffffff)
+        .element(GTElements.Cf)
+    event.create("hypercharged_oganesson") 
+        .plasma()
+        .color(0xa39672)
+        .element(GTElements.Og)
+    event.create("hypercharged_nihonium") 
+        .plasma()
+        .color(0x84a1e8)
+        .element(GTElements.Nh)
+    event.create("quark_gluon")
+        .plasma()
+        .color(0xc7cdcdd)
+    event.create("degenerate_gluon_condensate")
+        .liquid()
+        .color(0xf7d0ed)
+    event.create("astral_space_time_plasma")
+        .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
+        .components('1x astral_flux', '1x space_time')
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
+    event.create("chrono_infinity")
+        .ingot()
+        .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
+        .cableProperties(8589934592, 9001, 0, true)
+        .blastTemp(17000, 'highest', 536870912, 1800)
+        .element(GTElements.get("chrono_infinity"))
+        .color(0xffffff)
+        .iconSet('chrono-infinity_alloy')
+        .flags( 
+            GTMaterialFlags.GENERATE_FOIL, 
+            GTMaterialFlags.GENERATE_GEAR, 
+            GTMaterialFlags.GENERATE_SMALL_GEAR,
+            GTMaterialFlags.GENERATE_DENSE, 
+            GTMaterialFlags.GENERATE_RING, 
+            GTMaterialFlags.GENERATE_PLATE,
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_LONG_ROD,
+            GTMaterialFlags.GENERATE_ROTOR,
+            GTMaterialFlags.GENERATE_BOLT_SCREW,
+            GTMaterialFlags.GENERATE_ROUND,
+            GTMaterialFlags.GENERATE_SPRING,
+            GTMaterialFlags.GENERATE_SPRING_SMALL,
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.GENERATE_FRAME
+        );
 
-event.create("raw_cosmic_matter")
-.gas()
-.color(0x000000)
-event.create("crude_astral_flux")
-.plasma()
-.color(0x2c00ad)
-event.create("astral_flux") 
-.plasma()
-.color(0x4000ff)
-.element('astral_flux')
-event.create("hyper_ionized_helium")
-.plasma()
-.color(0xfff2ab)
-.formula('He⁺', true)
-event.create("infused_cosmic_matter")
-.gas()
-.color(0xaeabff)
-event.create("stabilized_raw_cosmic_matter")
-.gas()
-.color(0x14004f)
-event.create("cryo_compressed_raw_cosmic_matter")
-.gas()
-.color(0x00224f)
-event.create("cryogenic_neutron_flow")
-.liquid()
-.color(0x00fff7)
-event.create("shifted_cosmic_matter_base")
-.gas()
-.color(0x020078)
-event.create("plasma_tempered_cosmic_matter_base")
-.plasma()
-.color(0x060040)
-event.create("hyper_dense_cosmic_matter_base")
-.plasma()
-.color(0x020012)
-event.create("refined_cosmic_matter")
-.plasma()
-.color(0x1c00ff)
-event.create("cosmic_matter")
-.liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
-.element(GTElements.get("cosmic_matter"))
-.color(0xffffff)
-event.create("pure_cosmic_matter")
-.ingot()
-.element(GTElements.get("cosmic_matter"))
-.color(0xffffff)
-.iconSet('cosmic_matter')
-.flags(
-    GTMaterialFlags.GENERATE_PLATE, 
-    GTMaterialFlags.GENERATE_ROD, 
-    GTMaterialFlags.GENERATE_GEAR, 
-    GTMaterialFlags.GENERATE_FINE_WIRE,
-    GTMaterialFlags.GENERATE_DENSE, 
-    GTMaterialFlags.GENERATE_ROTOR, 
-    GTMaterialFlags.GENERATE_BOLT_SCREW,
-    GTMaterialFlags.GENERATE_SMALL_GEAR,
-    GTMaterialFlags.GENERATE_ROUND,
-    GTMaterialFlags.GENERATE_SPRING,
-    GTMaterialFlags.GENERATE_FRAME
-)
- 
-// PLASMAS NEBULA
 
-event.create("hypercharged_nebular") 
-.plasma()
-.color(0x1c03fc)
-.element('nebular_matter')
-event.create("high_entropy_neptunium") 
-.plasma()
-.color(0x03a1fc)
-.element(GTElements.Np)
-event.create("supercritical_californium") 
-.plasma()
-.color(0xffffff)
-.element(GTElements.Cf)
-event.create("hypercharged_oganesson") 
-.plasma()
-.color(0xa39672)
-.element(GTElements.Og)
-event.create("hypercharged_nihonium") 
-.plasma()
-.color(0x84a1e8)
-.element(GTElements.Nh)
-
-event.create("quark_gluon")
-    .plasma()
-    .color(0xc7cdcdd)
-event.create("degenerate_gluon_condensate")
-    .liquid()
-    .color(0xf7d0ed)
-
-event.create("astral_space_time_plasma")
-.liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
-.components('1x astral_flux', '1x space_time')
-.flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
-
-event.create("chrono_infinity")
-.ingot()
-.liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
-.cableProperties(8589934592, 9999, 0, true)
-.blastTemp(17000, 'highest', 536870912, 1800)
-.element(GTElements.get("chrono_infinity"))
-.color(0xffffff)
-.iconSet('chrono-infinity_alloy')
-.flags( 
-    GTMaterialFlags.GENERATE_FOIL, 
-    GTMaterialFlags.GENERATE_GEAR, 
-    GTMaterialFlags.GENERATE_SMALL_GEAR,
-    GTMaterialFlags.GENERATE_DENSE, 
-    GTMaterialFlags.GENERATE_RING, 
-    GTMaterialFlags.GENERATE_PLATE,
-    GTMaterialFlags.GENERATE_ROD,
-    GTMaterialFlags.GENERATE_LONG_ROD,
-    GTMaterialFlags.GENERATE_ROTOR,
-    GTMaterialFlags.GENERATE_BOLT_SCREW,
-    GTMaterialFlags.GENERATE_ROUND,
-    GTMaterialFlags.GENERATE_SPRING,
-    GTMaterialFlags.GENERATE_SPRING_SMALL,
-    GTMaterialFlags.GENERATE_FINE_WIRE,
-    GTMaterialFlags.GENERATE_FRAME
-)
-
- // Kerosene Line
+    // Kerosene Line
 
  	event.create('high_purity_kerosene')
         .liquid()
@@ -1905,14 +2210,14 @@ event.create("chrono_infinity")
         .plasma()
         .color(0xffc7cb)
         .element(GTElements.Ne)
-
     event.create('neutron_flux')
         .plasma()
         .color(0xdefff7)
     event.create('exotic_particle_suspension')
         .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
-        .flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
-
+        .flags(
+            GTMaterialFlags.DISABLE_DECOMPOSITION
+        );
     event.create('iridium_plasma')
         .plasma()
         .color(0x45f7e0)
@@ -1938,18 +2243,18 @@ event.create("chrono_infinity")
         .element('temporally_charged_silicon')
         .color(0xbdbbbb)
         .flags(
-        GTMaterialFlags.GENERATE_PLATE, 
-        GTMaterialFlags.GENERATE_ROD, 
-        GTMaterialFlags.GENERATE_GEAR, 
-        GTMaterialFlags.GENERATE_FINE_WIRE,
-        GTMaterialFlags.GENERATE_DENSE, 
-        GTMaterialFlags.GENERATE_ROTOR, 
-        GTMaterialFlags.GENERATE_BOLT_SCREW,
-        GTMaterialFlags.GENERATE_SMALL_GEAR,
-        GTMaterialFlags.GENERATE_ROUND,
-        GTMaterialFlags.GENERATE_SPRING,
-        GTMaterialFlags.GENERATE_FRAME
-        )
+            GTMaterialFlags.GENERATE_PLATE, 
+            GTMaterialFlags.GENERATE_ROD, 
+            GTMaterialFlags.GENERATE_GEAR, 
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.GENERATE_DENSE, 
+            GTMaterialFlags.GENERATE_ROTOR, 
+            GTMaterialFlags.GENERATE_BOLT_SCREW,
+            GTMaterialFlags.GENERATE_SMALL_GEAR,
+            GTMaterialFlags.GENERATE_ROUND,
+            GTMaterialFlags.GENERATE_SPRING,
+            GTMaterialFlags.GENERATE_FRAME
+        );
     event.create('exotic_condensate')
         .dust()
         .color(0x3b0aff)
@@ -1959,7 +2264,6 @@ event.create("chrono_infinity")
     event.create('decay_stabilized')
         .plasma()
         .color(0x23195e)
-
     event.create('solar_eclipse_alloy')
         .ingot()
         .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
@@ -1967,55 +2271,51 @@ event.create("chrono_infinity")
         .blastTemp(13500, 'highest', 1966080, 3400)
         .element('solar_eclipse_alloy')
         .flags(
-        GTMaterialFlags.GENERATE_PLATE, 
-        GTMaterialFlags.GENERATE_ROD, 
-        GTMaterialFlags.GENERATE_GEAR, 
-        GTMaterialFlags.GENERATE_FINE_WIRE,
-        GTMaterialFlags.GENERATE_DENSE, 
-        GTMaterialFlags.GENERATE_ROTOR, 
-        GTMaterialFlags.GENERATE_BOLT_SCREW,
-        GTMaterialFlags.GENERATE_SMALL_GEAR,
-        GTMaterialFlags.GENERATE_ROUND,
-        GTMaterialFlags.GENERATE_SPRING,
-        GTMaterialFlags.GENERATE_FRAME
-        )
-
+            GTMaterialFlags.GENERATE_PLATE, 
+            GTMaterialFlags.GENERATE_ROD, 
+            GTMaterialFlags.GENERATE_GEAR, 
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.GENERATE_DENSE, 
+            GTMaterialFlags.GENERATE_ROTOR, 
+            GTMaterialFlags.GENERATE_BOLT_SCREW,
+            GTMaterialFlags.GENERATE_SMALL_GEAR,
+            GTMaterialFlags.GENERATE_ROUND,
+            GTMaterialFlags.GENERATE_SPRING,
+            GTMaterialFlags.GENERATE_FRAME
+        );
     event.create('solar_radiation_alloy')
         .ingot()
         .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
         .iconSet('solar_radiation_alloy')
         .element('solar_radiation_alloy')
         .flags(
-        GTMaterialFlags.GENERATE_PLATE, 
-        GTMaterialFlags.GENERATE_ROD, 
-        GTMaterialFlags.GENERATE_GEAR, 
-        GTMaterialFlags.GENERATE_DENSE, 
-        GTMaterialFlags.GENERATE_ROTOR, 
-        GTMaterialFlags.GENERATE_BOLT_SCREW,
-        GTMaterialFlags.GENERATE_SMALL_GEAR,
-        GTMaterialFlags.GENERATE_ROUND,
-        GTMaterialFlags.GENERATE_SPRING,
-        GTMaterialFlags.GENERATE_FRAME
-        )
-       
+            GTMaterialFlags.GENERATE_PLATE, 
+            GTMaterialFlags.GENERATE_ROD, 
+            GTMaterialFlags.GENERATE_GEAR, 
+            GTMaterialFlags.GENERATE_DENSE, 
+            GTMaterialFlags.GENERATE_ROTOR, 
+            GTMaterialFlags.GENERATE_BOLT_SCREW,
+            GTMaterialFlags.GENERATE_SMALL_GEAR,
+            GTMaterialFlags.GENERATE_ROUND,
+            GTMaterialFlags.GENERATE_SPRING,
+            GTMaterialFlags.GENERATE_FRAME
+        );
     event.create('proto_matter')
         .ingot()
         .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
         .iconSet('proto_matter')
         .element('proto_matter')
         .flags(
-        GTMaterialFlags.GENERATE_PLATE, 
-        GTMaterialFlags.GENERATE_ROD, 
-        GTMaterialFlags.GENERATE_GEAR, 
-        GTMaterialFlags.GENERATE_FINE_WIRE,
-        GTMaterialFlags.GENERATE_DENSE, 
-        GTMaterialFlags.GENERATE_ROTOR, 
-        GTMaterialFlags.GENERATE_BOLT_SCREW,
-        GTMaterialFlags.GENERATE_SMALL_GEAR,
-        GTMaterialFlags.GENERATE_ROUND,
-        GTMaterialFlags.GENERATE_SPRING,
-        GTMaterialFlags.GENERATE_FRAME
-        )
-        
-
-    })
+            GTMaterialFlags.GENERATE_PLATE, 
+            GTMaterialFlags.GENERATE_ROD, 
+            GTMaterialFlags.GENERATE_GEAR, 
+            GTMaterialFlags.GENERATE_FINE_WIRE,
+            GTMaterialFlags.GENERATE_DENSE, 
+            GTMaterialFlags.GENERATE_ROTOR, 
+            GTMaterialFlags.GENERATE_BOLT_SCREW,
+            GTMaterialFlags.GENERATE_SMALL_GEAR,
+            GTMaterialFlags.GENERATE_ROUND,
+            GTMaterialFlags.GENERATE_SPRING,
+            GTMaterialFlags.GENERATE_FRAME
+        );
+})


### PR DESCRIPTION
    - Code Cleanup
    - Moved Electric Simulation Chamber Recipes to have the Circuit at the end
    - Superconductor Amp changes Heavily Modified Duty Alloy 64A -> 256A Crystal Superconductor 32A -> 256A Resonant Naquadah 128A -> 256A Chaos 512A -> 256A Hypoxylon 64A -> 256A Cosmic Neutronium 999A -> 256A Chrono-Infinity Alloy 9999A -> 9001
    - Deleting UEV and UIV Energy Converter recipes (wasn't supposed to exist in general)
    - Fixing Logs -> Stick recipe ratio
    - Adding Materials like Springs/Small Springs etc. for consistency in recipes
    - Added Recipe for Infinite Spray Can
    - Fixed Fine Wire Textures for Pure Cosmic Matter, Eternity, Universium and Stellar Matter Plasma
    - Changed Recipes to fit properly: UEV+ Auto Turbo Chargers UEV+ Singleblocks UEV+ Transformers UIV+ Diodes